### PR TITLE
Add bulk and scheduled minting on a shared materialization classifier

### DIFF
--- a/Jellyfin.Plugin.MindTheGaps.Tests/MintClassifierTests.cs
+++ b/Jellyfin.Plugin.MindTheGaps.Tests/MintClassifierTests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.MindTheGaps.Model;
+using Jellyfin.Plugin.MindTheGaps.VirtualItems;
+using Xunit;
+
+namespace Jellyfin.Plugin.MindTheGaps.Tests;
+
+public class MintClassifierTests
+{
+    private static GapItem Movie(string? tmdb, string? sourceType = null, string? sourceName = null)
+    {
+        var ids = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrEmpty(tmdb))
+        {
+            ids["Tmdb"] = tmdb;
+        }
+
+        return new GapItem
+        {
+            TargetKind = BaseItemKind.Movie,
+            Name = "A Movie",
+            ProviderIds = ids,
+            SourceItemType = sourceType,
+            SourceItemName = sourceName
+        };
+    }
+
+    [Fact]
+    public void Classify_CollectionMovie_IntoOwningBoxSet()
+    {
+        var c = MintClassifier.Classify(Movie("603", "BoxSet"));
+        Assert.True(c.IsMaterializable);
+        Assert.Equal(MintContainerKind.OwningBoxSet, c.ContainerKind);
+        Assert.Equal("603", c.TmdbId);
+        Assert.Null(c.PersonName);
+    }
+
+    [Fact]
+    public void Classify_FilmographyMovie_IntoCatchAll_AttachesPerson()
+    {
+        var c = MintClassifier.Classify(Movie("105", "Person", "Robert Zemeckis"));
+        Assert.True(c.IsMaterializable);
+        Assert.Equal(MintContainerKind.CatchAllCollection, c.ContainerKind);
+        Assert.Equal("Robert Zemeckis", c.PersonName);
+    }
+
+    [Fact]
+    public void Classify_RecommendationMovie_IntoCatchAll_NoPerson()
+    {
+        var c = MintClassifier.Classify(Movie("11", "Series"));
+        Assert.True(c.IsMaterializable);
+        Assert.Equal(MintContainerKind.CatchAllCollection, c.ContainerKind);
+        Assert.Null(c.PersonName);
+    }
+
+    [Fact]
+    public void Classify_MovieWithoutTmdb_NotMaterializable()
+    {
+        var gap = new GapItem
+        {
+            TargetKind = BaseItemKind.Movie,
+            Name = "No id",
+            ProviderIds = new Dictionary<string, string> { ["Imdb"] = "tt0000000" }
+        };
+        var c = MintClassifier.Classify(gap);
+        Assert.False(c.IsMaterializable);
+        Assert.Contains("TMDB", c.Reason, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Classify_Episode_NotMaterializable_NativeInCore()
+    {
+        var gap = new GapItem
+        {
+            TargetKind = BaseItemKind.Episode,
+            Name = "Show S01E01",
+            ProviderIds = new Dictionary<string, string> { ["Tmdb"] = "999" }
+        };
+        var c = MintClassifier.Classify(gap);
+        Assert.False(c.IsMaterializable);
+        Assert.Contains("natively", c.Reason, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Classify_Series_NotMaterializable()
+    {
+        var gap = new GapItem
+        {
+            TargetKind = BaseItemKind.Series,
+            Name = "A Series",
+            ProviderIds = new Dictionary<string, string> { ["Tmdb"] = "1399" }
+        };
+        Assert.False(MintClassifier.Classify(gap).IsMaterializable);
+    }
+}

--- a/Jellyfin.Plugin.MindTheGaps/Api/GapsController.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Api/GapsController.cs
@@ -247,6 +247,33 @@ public class GapsController : ControllerBase
     }
 
     /// <summary>
+    /// Starts a background mint of every materializable gap in the current report that matches an optional
+    /// pattern and/or domain (the dashboard's "Mint all in this tab"). Bounded by the configured cap, so a
+    /// large tab fills in over several clicks; poll <see cref="GetMintStatus"/>.
+    /// </summary>
+    /// <param name="pattern">An optional pattern name (for example SetCompletion); omitted matches all.</param>
+    /// <param name="domain">An optional domain name (for example Movies); omitted matches all.</param>
+    /// <param name="dryRun">When true, logs what would happen without writing anything.</param>
+    /// <returns>The mint status.</returns>
+    [HttpPost("MintAll")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult<MintStatus> MintAll([FromQuery] string? pattern, [FromQuery] string? domain, [FromQuery] bool dryRun)
+    {
+        var report = _store.LoadSnapshot();
+        var config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
+
+        GapPattern? patternFilter = Enum.TryParse<GapPattern>(pattern, ignoreCase: true, out var p) ? p : null;
+        MediaDomain? domainFilter = Enum.TryParse<MediaDomain>(domain, ignoreCase: true, out var d) ? d : null;
+
+        bool Filter(GapItem g) => (patternFilter is null || g.Pattern == patternFilter)
+            && (domainFilter is null || g.Domain == domainFilter);
+
+        var items = report.Items;
+        var started = _mintRunner.TryStart((progress, ct) => _minter.MintMatchingAsync(items, Filter, config.BulkMintCap, dryRun, progress, ct));
+        return new MintStatus { Running = true, Started = started };
+    }
+
+    /// <summary>
     /// Diagnoses why a gap is reported missing: most often a metadata mismatch where the library already
     /// holds the title under a different (or absent) provider id. Library-only, so it returns immediately.
     /// </summary>

--- a/Jellyfin.Plugin.MindTheGaps/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Configuration/PluginConfiguration.cs
@@ -42,6 +42,12 @@ public class PluginConfiguration : BasePluginConfiguration
         TvdbApiKey = string.Empty;
         TmdbApiKey = string.Empty;
         WebhookUrl = string.Empty;
+        BulkMintCap = 200;
+        AutoMint = false;
+        AutoMintSetCompletion = true;
+        AutoMintCreatorWorks = false;
+        AutoMintRecommendations = false;
+        AutoMintCap = 50;
     }
 
     /// <summary>
@@ -214,4 +220,37 @@ public class PluginConfiguration : BasePluginConfiguration
     /// finishes. The payload leads with a Discord-friendly "content" string. Empty disables it.
     /// </summary>
     public string WebhookUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the most gaps a single "Mint all in this tab" click materializes; the rest are left for
+    /// the next click. A guardrail against flooding a library in one action.
+    /// </summary>
+    public int BulkMintCap { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the scheduled auto-mint task mints new materializable gaps in
+    /// the selected patterns on the scan cadence. Off by default; reconciliation runs regardless.
+    /// </summary>
+    public bool AutoMint { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether auto-mint includes Set completion (collection) gaps.
+    /// </summary>
+    public bool AutoMintSetCompletion { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether auto-mint includes Creator works (filmography) gaps.
+    /// </summary>
+    public bool AutoMintCreatorWorks { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether auto-mint includes Recommendation gaps.
+    /// </summary>
+    public bool AutoMintRecommendations { get; set; }
+
+    /// <summary>
+    /// Gets or sets the most gaps one unattended auto-mint run materializes; the rest fill in over later
+    /// runs. A guardrail against flooding a library.
+    /// </summary>
+    public int AutoMintCap { get; set; }
 }

--- a/Jellyfin.Plugin.MindTheGaps/ScheduledTasks/AutoMintTask.cs
+++ b/Jellyfin.Plugin.MindTheGaps/ScheduledTasks/AutoMintTask.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.MindTheGaps.Configuration;
+using Jellyfin.Plugin.MindTheGaps.Gaps;
+using Jellyfin.Plugin.MindTheGaps.Model;
+using Jellyfin.Plugin.MindTheGaps.VirtualItems;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.MindTheGaps.ScheduledTasks;
+
+/// <summary>
+/// Opt-in scheduled task that mints virtual placeholders for new materializable gaps in the patterns chosen
+/// in settings. Off by default and with no default trigger, so it runs only once an admin turns it on and
+/// schedules it. Reconciliation of placeholders the library now owns for real runs at the end of every scan,
+/// independent of this task, so this only adds; the per-run cap keeps it from flooding a library.
+/// </summary>
+public sealed class AutoMintTask : IScheduledTask
+{
+    private readonly GapStore _store;
+    private readonly VirtualMovieMinter _minter;
+    private readonly ILogger<AutoMintTask> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AutoMintTask"/> class.
+    /// </summary>
+    /// <param name="store">The gap store (the source of gaps to mint).</param>
+    /// <param name="minter">The virtual-movie minter.</param>
+    /// <param name="logger">The logger.</param>
+    public AutoMintTask(GapStore store, VirtualMovieMinter minter, ILogger<AutoMintTask> logger)
+    {
+        _store = store;
+        _minter = minter;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string Name => "Auto-mint gaps";
+
+    /// <inheritdoc />
+    public string Key => "MindTheGapsAutoMint";
+
+    /// <inheritdoc />
+    public string Description => "When enabled in settings, mints virtual placeholders for new materializable gaps in the selected patterns. Off by default.";
+
+    /// <inheritdoc />
+    public string Category => "Mind the Gaps";
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        var config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
+        if (!config.AutoMint)
+        {
+            _logger.LogDebug("Auto-mint is off; nothing to do");
+            progress.Report(100);
+            return;
+        }
+
+        var patterns = SelectedPatterns(config);
+        if (patterns.Count == 0)
+        {
+            _logger.LogInformation("Auto-mint is on but no patterns are selected; nothing to do");
+            progress.Report(100);
+            return;
+        }
+
+        var report = _store.LoadSnapshot();
+        var message = await _minter.MintMatchingAsync(
+            report.Items,
+            gap => patterns.Contains(gap.Pattern),
+            config.AutoMintCap,
+            dryRun: false,
+            progress,
+            cancellationToken).ConfigureAwait(false);
+        _logger.LogInformation("Auto-mint complete: {Message}", message);
+        progress.Report(100);
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
+    {
+        // No default trigger: the task is opt-in, so it only runs once an admin enables auto-mint and adds a
+        // schedule for it.
+        yield break;
+    }
+
+    private static HashSet<GapPattern> SelectedPatterns(PluginConfiguration config)
+    {
+        var patterns = new HashSet<GapPattern>();
+        if (config.AutoMintSetCompletion)
+        {
+            patterns.Add(GapPattern.SetCompletion);
+        }
+
+        if (config.AutoMintCreatorWorks)
+        {
+            patterns.Add(GapPattern.CreatorWorks);
+        }
+
+        if (config.AutoMintRecommendations)
+        {
+            patterns.Add(GapPattern.Recommendation);
+        }
+
+        return patterns;
+    }
+}

--- a/Jellyfin.Plugin.MindTheGaps/VirtualItems/MintClassification.cs
+++ b/Jellyfin.Plugin.MindTheGaps/VirtualItems/MintClassification.cs
@@ -1,0 +1,70 @@
+using System;
+
+namespace Jellyfin.Plugin.MindTheGaps.VirtualItems;
+
+/// <summary>
+/// The outcome of classifying a gap for minting: whether it can be materialized as a virtual item today, and
+/// if so, which container it belongs in, its TMDB id, and the person (if any) to attach. Pure data, so the
+/// per-row, multi-select, bulk, and scheduled mint paths share one decision instead of repeating the guards.
+/// </summary>
+public sealed class MintClassification
+{
+    private MintClassification(bool isMaterializable, MintContainerKind containerKind, string? tmdbId, string? personName, string reason)
+    {
+        IsMaterializable = isMaterializable;
+        ContainerKind = containerKind;
+        TmdbId = tmdbId;
+        PersonName = personName;
+        Reason = reason;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the gap can be minted today.
+    /// </summary>
+    public bool IsMaterializable { get; }
+
+    /// <summary>
+    /// Gets the container the placeholder belongs in (meaningful only when materializable).
+    /// </summary>
+    public MintContainerKind ContainerKind { get; }
+
+    /// <summary>
+    /// Gets the gap's TMDB id (non-null when materializable).
+    /// </summary>
+    public string? TmdbId { get; }
+
+    /// <summary>
+    /// Gets the person to attach (a filmography gap's owner), or null.
+    /// </summary>
+    public string? PersonName { get; }
+
+    /// <summary>
+    /// Gets the human-readable reason, used as the skip message when not materializable.
+    /// </summary>
+    public string Reason { get; }
+
+    /// <summary>
+    /// Creates a non-materializable result with the reason it cannot be minted.
+    /// </summary>
+    /// <param name="reason">Why the gap cannot be minted.</param>
+    /// <returns>A non-materializable classification.</returns>
+    public static MintClassification NotMaterializable(string reason)
+        => new(false, MintContainerKind.CatchAllCollection, null, null, reason);
+
+    /// <summary>
+    /// Creates a materializable result.
+    /// </summary>
+    /// <param name="containerKind">The container the placeholder belongs in.</param>
+    /// <param name="tmdbId">The gap's TMDB id (required).</param>
+    /// <param name="personName">The person to attach, or null.</param>
+    /// <returns>A materializable classification.</returns>
+    public static MintClassification Materializable(MintContainerKind containerKind, string tmdbId, string? personName)
+    {
+        if (string.IsNullOrEmpty(tmdbId))
+        {
+            throw new ArgumentException("A materializable gap must have a TMDB id.", nameof(tmdbId));
+        }
+
+        return new MintClassification(true, containerKind, tmdbId, personName, "Materializable.");
+    }
+}

--- a/Jellyfin.Plugin.MindTheGaps/VirtualItems/MintClassifier.cs
+++ b/Jellyfin.Plugin.MindTheGaps/VirtualItems/MintClassifier.cs
@@ -1,0 +1,61 @@
+using System;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.MindTheGaps.Model;
+
+namespace Jellyfin.Plugin.MindTheGaps.VirtualItems;
+
+/// <summary>
+/// Decides whether a gap can be minted as a virtual movie today and, if so, which container it belongs in
+/// and which person to attach. Pure and library-free, so every mint path (per-row, multi-select, bulk,
+/// scheduled) shares the same rule. Today only Movie gaps with a TMDB id are materializable; episodes are
+/// materialized natively by the host, and other kinds are not minted yet.
+/// </summary>
+public static class MintClassifier
+{
+    /// <summary>
+    /// Classifies a gap for minting.
+    /// </summary>
+    /// <param name="gap">The gap to classify.</param>
+    /// <returns>The classification.</returns>
+    public static MintClassification Classify(GapItem gap)
+    {
+        ArgumentNullException.ThrowIfNull(gap);
+
+        if (gap.TargetKind == BaseItemKind.Episode)
+        {
+            return MintClassification.NotMaterializable("Episodes are materialized natively by the server, not minted.");
+        }
+
+        if (gap.TargetKind != BaseItemKind.Movie)
+        {
+            return MintClassification.NotMaterializable(string.Format(System.Globalization.CultureInfo.InvariantCulture, "Only Movie gaps can be minted today; '{0}' is a {1}.", gap.Name, gap.TargetKind));
+        }
+
+        if (!TryGetTmdbId(gap, out var tmdbId))
+        {
+            return MintClassification.NotMaterializable(string.Format(System.Globalization.CultureInfo.InvariantCulture, "'{0}' has no TMDB id; cannot mint.", gap.Name));
+        }
+
+        // A collection gap goes into its owning BoxSet; a filmography or recommendation gap goes into the
+        // shared catch-all collection, and a filmography (Person) gap also attaches the person so the minted
+        // movie surfaces on that person's page.
+        var containerKind = string.Equals(gap.SourceItemType, "BoxSet", StringComparison.Ordinal)
+            ? MintContainerKind.OwningBoxSet
+            : MintContainerKind.CatchAllCollection;
+        var personName = string.Equals(gap.SourceItemType, "Person", StringComparison.Ordinal) ? gap.SourceItemName : null;
+
+        return MintClassification.Materializable(containerKind, tmdbId, personName);
+    }
+
+    private static bool TryGetTmdbId(GapItem gap, out string tmdbId)
+    {
+        if (gap.ProviderIds.TryGetValue("Tmdb", out var id) && !string.IsNullOrEmpty(id))
+        {
+            tmdbId = id;
+            return true;
+        }
+
+        tmdbId = string.Empty;
+        return false;
+    }
+}

--- a/Jellyfin.Plugin.MindTheGaps/VirtualItems/MintContainerKind.cs
+++ b/Jellyfin.Plugin.MindTheGaps/VirtualItems/MintContainerKind.cs
@@ -1,0 +1,18 @@
+namespace Jellyfin.Plugin.MindTheGaps.VirtualItems;
+
+/// <summary>
+/// Where a materializable gap's virtual placeholder belongs.
+/// </summary>
+public enum MintContainerKind
+{
+    /// <summary>
+    /// The gap names an owning BoxSet (a collection gap); the placeholder goes into that BoxSet.
+    /// </summary>
+    OwningBoxSet = 0,
+
+    /// <summary>
+    /// The gap has no owning BoxSet (a filmography or recommendation gap); the placeholder goes into the
+    /// shared catch-all collection.
+    /// </summary>
+    CatchAllCollection = 1
+}

--- a/Jellyfin.Plugin.MindTheGaps/VirtualItems/VirtualMovieMinter.cs
+++ b/Jellyfin.Plugin.MindTheGaps/VirtualItems/VirtualMovieMinter.cs
@@ -184,22 +184,15 @@ public sealed class VirtualMovieMinter : IDisposable
     {
         var stopwatch = Stopwatch.StartNew();
 
-        if (gap.TargetKind != BaseItemKind.Movie)
+        var classification = MintClassifier.Classify(gap);
+        if (!classification.IsMaterializable)
         {
-            _logger.LogInformation(
-                "One-off mint skipped: '{Name}' is a {Kind}; only Movie gaps are mintable today",
-                gap.Name,
-                gap.TargetKind);
-            return string.Create(CultureInfo.InvariantCulture, $"Only Movie gaps can be minted today; '{gap.Name}' is a {gap.TargetKind}.");
+            _logger.LogInformation("One-off mint skipped: {Reason}", classification.Reason);
+            return classification.Reason;
         }
 
-        if (!gap.ProviderIds.TryGetValue("Tmdb", out var tmdbId) || string.IsNullOrEmpty(tmdbId))
-        {
-            _logger.LogWarning("One-off mint skipped: '{Name}' has no TMDB id", gap.Name);
-            return string.Create(CultureInfo.InvariantCulture, $"'{gap.Name}' has no TMDB id; cannot mint.");
-        }
-
-        var personName = string.Equals(gap.SourceItemType, "Person", StringComparison.Ordinal) ? gap.SourceItemName : null;
+        var tmdbId = classification.TmdbId!;
+        var personName = classification.PersonName;
         var personSuffix = string.IsNullOrEmpty(personName)
             ? string.Empty
             : string.Create(CultureInfo.InvariantCulture, $" and attach person '{personName}'");
@@ -315,9 +308,7 @@ public sealed class VirtualMovieMinter : IDisposable
 
             // The report only offers Mint on movie gaps with a TMDB id; count anything else as skipped
             // rather than minted, so the total reflects actual mint attempts (MintGapAsync would no-op it).
-            if (gap.TargetKind != BaseItemKind.Movie
-                || !gap.ProviderIds.TryGetValue("Tmdb", out var tmdbId)
-                || string.IsNullOrEmpty(tmdbId))
+            if (!MintClassifier.Classify(gap).IsMaterializable)
             {
                 skipped++;
                 continue;
@@ -349,6 +340,55 @@ public sealed class VirtualMovieMinter : IDisposable
         return failed == 0
             ? string.Create(CultureInfo.InvariantCulture, $"{verb} {minted} item(s){skippedSuffix}.")
             : string.Create(CultureInfo.InvariantCulture, $"{verb} {minted} item(s){skippedSuffix}, {failed} failed. Check the server logs.");
+    }
+
+    /// <summary>
+    /// Mints every candidate gap that matches a filter and is materializable, up to a cap. Shared by the
+    /// bulk "mint all in this tab" action and the scheduled auto-mint task, both of which pass the current
+    /// report's items and a pattern/domain filter. Reconciliation of already-owned placeholders runs at the
+    /// end of every scan, independent of this.
+    /// </summary>
+    /// <param name="candidates">The gaps to consider (typically the current report's items); null is treated as empty.</param>
+    /// <param name="filter">Selects which gaps to mint.</param>
+    /// <param name="cap">The most gaps to mint this run; zero or less uses the built-in cap.</param>
+    /// <param name="dryRun">When true, logs what would happen without writing anything.</param>
+    /// <param name="progress">Optional progress sink (0-100).</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A human-readable status message.</returns>
+    public async Task<string> MintMatchingAsync(IReadOnlyList<GapItem>? candidates, Func<GapItem, bool> filter, int cap, bool dryRun, IProgress<double>? progress, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        var effectiveCap = cap > 0 ? Math.Min(cap, MaxMintSelection) : MaxMintSelection;
+        var selected = new List<GapItem>();
+        var overCap = false;
+        foreach (var gap in candidates ?? Array.Empty<GapItem>())
+        {
+            if (!filter(gap) || !MintClassifier.Classify(gap).IsMaterializable)
+            {
+                continue;
+            }
+
+            if (selected.Count >= effectiveCap)
+            {
+                overCap = true;
+                break;
+            }
+
+            selected.Add(gap);
+        }
+
+        if (selected.Count == 0)
+        {
+            return "No materializable gaps matched.";
+        }
+
+        if (overCap)
+        {
+            _logger.LogInformation("Bulk mint: matched more than the cap of {Cap}; the rest are left for the next run", effectiveCap);
+        }
+
+        return await MintGapsAsync(selected, dryRun, progress, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<BaseItem?> ResolveContainerAsync(GapItem gap, bool dryRun, CancellationToken cancellationToken)

--- a/Jellyfin.Plugin.MindTheGaps/Web/mindthegaps.config.html
+++ b/Jellyfin.Plugin.MindTheGaps/Web/mindthegaps.config.html
@@ -242,6 +242,46 @@
                                     <span>Remove minted movies</span>
                                 </button>
                             </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="BulkMintCap">Mint all cap (per click)</label>
+                                <input id="BulkMintCap" name="BulkMintCap" type="number" min="1" is="emby-input" />
+                                <div class="fieldDescription">The most gaps one "Mint all in this tab" click materializes; the rest fill in on the next click.</div>
+                            </div>
+                            <h3 class="checkboxListLabel" style="margin-top:1em;">Scheduled auto-mint</h3>
+                            <p class="fieldDescription" style="color:#e08000;">
+                                Off by default. When on, the "Auto-mint gaps" scheduled task (give it a schedule under
+                                Scheduled Tasks) mints new materializable gaps in the patterns picked below. Reconciliation
+                                of placeholders the library later owns for real runs at the end of every scan regardless.
+                            </p>
+                            <div class="checkboxContainer">
+                                <label class="emby-checkbox-label">
+                                    <input id="AutoMint" name="AutoMint" type="checkbox" is="emby-checkbox" />
+                                    <span>Auto-mint on the scan schedule</span>
+                                </label>
+                            </div>
+                            <div class="checkboxContainer">
+                                <label class="emby-checkbox-label">
+                                    <input id="AutoMintSetCompletion" name="AutoMintSetCompletion" type="checkbox" is="emby-checkbox" />
+                                    <span>Auto-mint Set completion (collection) gaps</span>
+                                </label>
+                            </div>
+                            <div class="checkboxContainer">
+                                <label class="emby-checkbox-label">
+                                    <input id="AutoMintCreatorWorks" name="AutoMintCreatorWorks" type="checkbox" is="emby-checkbox" />
+                                    <span>Auto-mint Creator works (filmography) gaps</span>
+                                </label>
+                            </div>
+                            <div class="checkboxContainer">
+                                <label class="emby-checkbox-label">
+                                    <input id="AutoMintRecommendations" name="AutoMintRecommendations" type="checkbox" is="emby-checkbox" />
+                                    <span>Auto-mint Recommendation gaps</span>
+                                </label>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="AutoMintCap">Auto-mint cap (per run)</label>
+                                <input id="AutoMintCap" name="AutoMintCap" type="number" min="1" is="emby-input" />
+                                <div class="fieldDescription">The most gaps one unattended run materializes; the rest fill in over later runs.</div>
+                            </div>
                         </div>
 
                         <div>

--- a/Jellyfin.Plugin.MindTheGaps/Web/mindthegaps.js
+++ b/Jellyfin.Plugin.MindTheGaps/Web/mindthegaps.js
@@ -1336,6 +1336,19 @@
                 // no rows until expanded, so the bar is re-evaluated when a group is opened, not just on render.
                 function refreshSelectBar(page) {
                     page.querySelector('#cgSelectBar').style.display = page.querySelector('#cgList .cgSel') ? 'flex' : 'none';
+                    updateMintAll(page);
+                }
+
+                // Count the materializable gaps in the current tab (movies with a TMDB id; the server applies
+                // the same rule) and show the "Mint all in this tab" button only when there are some.
+                function updateMintAll(page) {
+                    var bar = page.querySelector('#cgMintAllBar');
+                    if (!bar) { return; }
+                    var n = ((page._report && page._report.Items) || []).filter(function (it) {
+                        return it.PatternName === page._pattern && it.TargetKindName === 'Movie' && it.ProviderIds && it.ProviderIds.Tmdb;
+                    }).length;
+                    page.querySelector('#cgMintAllCount').textContent = n;
+                    bar.style.display = n ? 'flex' : 'none';
                 }
 
                 // The ids of the checked rows. Mint rehydrates each from the stored report server-side, so the
@@ -1846,6 +1859,12 @@
                     page.querySelector('#MaxFilmographyPeople').value = config.MaxFilmographyPeople;
                     page.querySelector('#MinFilmographyVotes').value = config.MinFilmographyVotes;
                     page.querySelector('#MaxCastBillingOrder').value = config.MaxCastBillingOrder;
+                    page.querySelector('#BulkMintCap').value = config.BulkMintCap;
+                    page.querySelector('#AutoMint').checked = config.AutoMint;
+                    page.querySelector('#AutoMintSetCompletion').checked = config.AutoMintSetCompletion;
+                    page.querySelector('#AutoMintCreatorWorks').checked = config.AutoMintCreatorWorks;
+                    page.querySelector('#AutoMintRecommendations').checked = config.AutoMintRecommendations;
+                    page.querySelector('#AutoMintCap').value = config.AutoMintCap;
                     bindSettingsToggle(page, 'TraktEnabled', 'TraktClientId');
                     bindSettingsToggle(page, 'TvdbEnabled', 'TvdbApiKey');
                     // Freshly loaded values are not unsaved edits (assigning .value/.checked fires no events).
@@ -1922,6 +1941,12 @@
                         config.MaxFilmographyPeople = parseInt(form.querySelector('#MaxFilmographyPeople').value || '1000', 10);
                         config.MinFilmographyVotes = parseInt(form.querySelector('#MinFilmographyVotes').value || '0', 10);
                         config.MaxCastBillingOrder = parseInt(form.querySelector('#MaxCastBillingOrder').value || '0', 10);
+                        config.BulkMintCap = parseInt(form.querySelector('#BulkMintCap').value || '200', 10);
+                        config.AutoMint = form.querySelector('#AutoMint').checked;
+                        config.AutoMintSetCompletion = form.querySelector('#AutoMintSetCompletion').checked;
+                        config.AutoMintCreatorWorks = form.querySelector('#AutoMintCreatorWorks').checked;
+                        config.AutoMintRecommendations = form.querySelector('#AutoMintRecommendations').checked;
+                        config.AutoMintCap = parseInt(form.querySelector('#AutoMintCap').value || '50', 10);
                         ApiClient.updatePluginConfiguration(pluginId, config).then(function (result) {
                             page._settingsDirty = false;
                             cgRegion = (config.MetadataCountryCode || '').trim().toLowerCase();
@@ -2226,6 +2251,44 @@
                           .catch(function () {
                             done('Bulk mint failed. Check the server logs.');
                         });
+                    });
+                    page.querySelector('#cgMintAll').addEventListener('click', function () {
+                        var pattern = page._pattern;
+                        var count = page.querySelector('#cgMintAllCount').textContent || '0';
+                        if (!window.confirm('Mint ' + count + ' materializable item(s) in this tab as virtual placeholders? Bounded by the configured cap; the rest fill in on the next click.')) { return; }
+                        var btn = this;
+                        var label = btn.querySelectorAll('span')[1];
+                        var labelHtml = label ? label.innerHTML : '';
+                        btn.disabled = true;
+
+                        function done(msg) {
+                            if (label) { label.innerHTML = labelHtml; }
+                            btn.disabled = false;
+                            if (msg) { Dashboard.alert(msg); }
+                        }
+                        function pollMint() {
+                            if (!pageActive(page)) { return; }
+                            ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl('MindTheGaps/MintStatus'), dataType: 'json' })
+                                .then(function (s) {
+                                    if (s && s.Running) {
+                                        if (label) { label.textContent = 'Minting… ' + Math.round(s.Progress || 0) + '%'; }
+                                        setTimeout(pollMint, 1500);
+                                    } else {
+                                        done();
+                                        Dashboard.alert((s && s.Message) || 'Done.');
+                                        load(page);
+                                    }
+                                })
+                                .catch(function () { done('Lost contact while minting. Check the server logs.'); });
+                        }
+
+                        if (label) { label.textContent = 'Minting…'; }
+                        ApiClient.ajax({
+                            type: 'POST',
+                            url: ApiClient.getUrl('MindTheGaps/MintAll', { pattern: pattern || '' }),
+                            dataType: 'json'
+                        }).then(function () { setTimeout(pollMint, 800); })
+                          .catch(function () { done('Mint all failed. Check the server logs.'); });
                     });
                     page.querySelector('#cgRescan').addEventListener('click', function () {
                         startScan(page, this);

--- a/Jellyfin.Plugin.MindTheGaps/Web/mindthegaps.report.html
+++ b/Jellyfin.Plugin.MindTheGaps/Web/mindthegaps.report.html
@@ -83,6 +83,13 @@
                     </button>
                 </div>
 
+                <div id="cgMintAllBar" style="display:none;align-items:center;gap:.5em;margin:.3em 0;flex-wrap:wrap;">
+                    <button is="emby-button" type="button" id="cgMintAll" class="raised" title="Mint a virtual placeholder for every materializable gap in this tab (movies with a TMDB id; episodes are native in core)">
+                        <span class="material-icons" aria-hidden="true" style="margin-right:.2em;">eco</span>
+                        <span>Mint all in this tab (<span id="cgMintAllCount">0</span>)</span>
+                    </button>
+                </div>
+
                 <div id="cgJump" style="display:none;"></div>
                 <div id="cgRollup" style="display:none;"></div>
                 <div id="cgList" class="itemsContainer vertical-list"></div>


### PR DESCRIPTION
A pure MintClassifier decides whether a gap can be minted today (a Movie with a TMDB id; episodes are native in core, other kinds are not minted yet), which container it belongs in (its owning BoxSet, or the catch-all collection), and which person to attach. The per-row and multi-select mint paths now share that one decision, and a new MintMatchingAsync mints every materializable gap that matches a filter up to a cap.

- Mint all in this tab: a report button mints every materializable gap in the current pattern, bounded by BulkMintCap, with the same background progress and polling as the multi-select mint.
- Auto-mint: an opt-in AutoMintTask (off by default, no default trigger) mints new materializable gaps in the chosen patterns on a schedule the admin adds, bounded by AutoMintCap. Reconciliation still runs at the end of every scan.
- Settings gain the two caps and the auto-mint pattern toggles.
- Tests cover the classifier across collection, filmography, recommendation, no-TMDB, episode, and series gaps.