### PR TITLE
Best-effort reuse of an installed plugin's TheTVDB key

### DIFF
--- a/Jellyfin.Plugin.MindTheGaps/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Configuration/PluginConfiguration.cs
@@ -42,6 +42,7 @@ public class PluginConfiguration : BasePluginConfiguration
         TvdbApiKey = string.Empty;
         TmdbApiKey = string.Empty;
         WebhookUrl = string.Empty;
+        ReuseInstalledProviderKeys = false;
     }
 
     /// <summary>
@@ -214,4 +215,12 @@ public class PluginConfiguration : BasePluginConfiguration
     /// finishes. The payload leads with a Discord-friendly "content" string. Empty disables it.
     /// </summary>
     public string WebhookUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether, when one of this plugin's own provider keys is blank, it may
+    /// make a best-effort read of the matching installed metadata plugin's configured key (for example the
+    /// in-box TheTVDB plugin). There is no supported host API for this, so it is version-fragile and falls
+    /// back silently to this plugin's own keys. Off by default.
+    /// </summary>
+    public bool ReuseInstalledProviderKeys { get; set; }
 }

--- a/Jellyfin.Plugin.MindTheGaps/Gaps/Sources/Series/TvdbContentGapSource.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Gaps/Sources/Series/TvdbContentGapSource.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.MindTheGaps.Configuration;
 using Jellyfin.Plugin.MindTheGaps.Gaps;
+using Jellyfin.Plugin.MindTheGaps.Services;
 using Jellyfin.Plugin.MindTheGaps.Services.Http;
 using Jellyfin.Plugin.MindTheGaps.Services.Tvdb;
 using MediaBrowser.Controller.Entities;
@@ -20,6 +21,7 @@ namespace Jellyfin.Plugin.MindTheGaps.Gaps.Sources.Series;
 public sealed class TvdbContentGapSource : SeriesContentGapSourceBase
 {
     private readonly TvdbClient _client;
+    private readonly InstalledPluginCredentials _credentials;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TvdbContentGapSource"/> class.
@@ -27,11 +29,13 @@ public sealed class TvdbContentGapSource : SeriesContentGapSourceBase
     /// <param name="libraryManager">The library manager.</param>
     /// <param name="client">The TheTVDB client.</param>
     /// <param name="cursors">The scan-rotation cursor store.</param>
+    /// <param name="credentials">Best-effort reuse of an installed plugin's TheTVDB key when ours is blank.</param>
     /// <param name="logger">The logger.</param>
-    public TvdbContentGapSource(ILibraryManager libraryManager, TvdbClient client, ScanCursorStore cursors, ILogger<TvdbContentGapSource> logger)
+    public TvdbContentGapSource(ILibraryManager libraryManager, TvdbClient client, ScanCursorStore cursors, InstalledPluginCredentials credentials, ILogger<TvdbContentGapSource> logger)
         : base(libraryManager, cursors, logger)
     {
         _client = client;
+        _credentials = credentials;
     }
 
     /// <inheritdoc />
@@ -45,7 +49,7 @@ public sealed class TvdbContentGapSource : SeriesContentGapSourceBase
 
     /// <inheritdoc />
     public override bool IsEnabled(PluginConfiguration config)
-        => config.ScanSeries && config.TvdbEnabled && !string.IsNullOrWhiteSpace(config.TvdbApiKey);
+        => config.ScanSeries && config.TvdbEnabled && !string.IsNullOrWhiteSpace(ResolveApiKey(config));
 
     /// <inheritdoc />
     protected override bool HasLookupId(BaseItem series)
@@ -59,7 +63,7 @@ public sealed class TvdbContentGapSource : SeriesContentGapSourceBase
         GapScanContext context,
         CancellationToken cancellationToken)
     {
-        var apiKey = context.Config.TvdbApiKey;
+        var apiKey = ResolveApiKey(context.Config);
 
         var seriesId = await ResolveSeriesIdAsync(series, apiKey, cancellationToken).ConfigureAwait(false);
         if (seriesId is null)
@@ -73,6 +77,19 @@ public sealed class TvdbContentGapSource : SeriesContentGapSourceBase
 
     private static string? Id(BaseItem item, string provider)
         => item.TryGetProviderId(provider, out var value) && !string.IsNullOrEmpty(value) ? value : null;
+
+    // Prefer the user's own configured TheTVDB key. Only when it is blank and reuse is opted in do we try a
+    // best-effort read of an installed TheTVDB plugin's key; a discovery failure falls back to empty (the
+    // source then reports itself disabled), so this never breaks the scan.
+    private string ResolveApiKey(PluginConfiguration config)
+    {
+        if (!string.IsNullOrWhiteSpace(config.TvdbApiKey))
+        {
+            return config.TvdbApiKey;
+        }
+
+        return config.ReuseInstalledProviderKeys ? _credentials.TryGetTvdbApiKey() ?? string.Empty : string.Empty;
+    }
 
     private async Task<long?> ResolveSeriesIdAsync(BaseItem series, string apiKey, CancellationToken cancellationToken)
     {

--- a/Jellyfin.Plugin.MindTheGaps/ServiceRegistrator.cs
+++ b/Jellyfin.Plugin.MindTheGaps/ServiceRegistrator.cs
@@ -6,6 +6,7 @@ using Jellyfin.Plugin.MindTheGaps.Gaps.Sources.Music;
 using Jellyfin.Plugin.MindTheGaps.Gaps.Sources.Series;
 using Jellyfin.Plugin.MindTheGaps.Gaps.Sources.Tmdb;
 using Jellyfin.Plugin.MindTheGaps.Gaps.Sources.Trakt;
+using Jellyfin.Plugin.MindTheGaps.Services;
 using Jellyfin.Plugin.MindTheGaps.Services.Availability;
 using Jellyfin.Plugin.MindTheGaps.Services.Diagnostics;
 using Jellyfin.Plugin.MindTheGaps.Services.Discogs;
@@ -51,6 +52,7 @@ public sealed class ServiceRegistrator : IPluginServiceRegistrator
         serviceCollection.AddSingleton<VirtualMovieMinter>();
         serviceCollection.AddSingleton<MintRunner>();
         serviceCollection.AddSingleton<GapDiagnostics>();
+        serviceCollection.AddSingleton<InstalledPluginCredentials>();
 
         // Availability sources + aggregator + background enrichment runner.
         serviceCollection.AddSingleton<AvailabilityService>();

--- a/Jellyfin.Plugin.MindTheGaps/Services/InstalledPluginCredentials.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Services/InstalledPluginCredentials.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Reflection;
+using MediaBrowser.Common.Plugins;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.MindTheGaps.Services;
+
+/// <summary>
+/// Best-effort, guarded reflection into another installed plugin's configuration to read an API key when
+/// this plugin's own is blank. There is no supported host API for reading another plugin's secrets, so this
+/// reflects into the foreign plugin's <c>Configuration</c> by assembly name and property name; any failure
+/// (the plugin absent, disabled, its config property renamed, a type mismatch) returns null and never
+/// throws. The caller must already have checked that reuse is opted in and its own key is blank. Fragile and
+/// version-coupled by design; see docs/credentials-spike.md.
+/// </summary>
+public sealed class InstalledPluginCredentials
+{
+    private const string TvdbPluginAssembly = "Jellyfin.Plugin.Tvdb";
+
+    // Tried in order; the in-box TheTVDB plugin's subscriber key has gone by a few names across versions.
+    private static readonly string[] _tvdbKeyPropertyNames = { "SubscriberPIN", "SubscriberPin", "ApiKey" };
+
+    private readonly IPluginManager _pluginManager;
+    private readonly ILogger<InstalledPluginCredentials> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InstalledPluginCredentials"/> class.
+    /// </summary>
+    /// <param name="pluginManager">The host plugin manager, used to enumerate installed plugins.</param>
+    /// <param name="logger">The logger.</param>
+    public InstalledPluginCredentials(IPluginManager pluginManager, ILogger<InstalledPluginCredentials> logger)
+    {
+        _pluginManager = pluginManager;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns the installed TheTVDB plugin's subscriber key/PIN if one is present and non-empty, or null on
+    /// any failure (plugin absent, disabled, property renamed, or other reflection error).
+    /// </summary>
+    /// <returns>The discovered key, or null.</returns>
+    public string? TryGetTvdbApiKey() => TryReadPluginConfigString(TvdbPluginAssembly, _tvdbKeyPropertyNames);
+
+    private string? TryReadPluginConfigString(string assemblyName, string[] propertyNames)
+    {
+        try
+        {
+            foreach (var local in _pluginManager.Plugins)
+            {
+                var instance = local.Instance;
+                if (instance is null)
+                {
+                    continue;
+                }
+
+                var type = instance.GetType();
+                if (!string.Equals(type.Assembly.GetName().Name, assemblyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var config = type.GetProperty("Configuration", BindingFlags.Public | BindingFlags.Instance)?.GetValue(instance);
+                if (config is null)
+                {
+                    return null;
+                }
+
+                foreach (var name in propertyNames)
+                {
+                    if (config.GetType().GetProperty(name, BindingFlags.Public | BindingFlags.Instance)?.GetValue(config) is string value
+                        && !string.IsNullOrWhiteSpace(value))
+                    {
+                        _logger.LogInformation("Reusing an API key from installed plugin '{Plugin}' (property '{Property}')", instance.Name, name);
+                        return value;
+                    }
+                }
+
+                return null;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Best-effort credential reuse failed for {Assembly}", assemblyName);
+        }
+
+        return null;
+    }
+}

--- a/Jellyfin.Plugin.MindTheGaps/Web/mindthegaps.config.html
+++ b/Jellyfin.Plugin.MindTheGaps/Web/mindthegaps.config.html
@@ -154,6 +154,13 @@
                             </div>
                             <div class="checkboxContainer checkboxContainer-withDescription">
                                 <label class="emby-checkbox-label">
+                                    <input id="ReuseInstalledProviderKeys" name="ReuseInstalledProviderKeys" type="checkbox" is="emby-checkbox" />
+                                    <span>Reuse an installed plugin's key when ours is blank (best-effort)</span>
+                                </label>
+                                <div class="fieldDescription">When the TheTVDB key above is blank, try reading the matching installed metadata plugin's configured key (the in-box TheTVDB plugin). There is no supported host API for this, so it is best-effort and version-fragile, and falls back silently to the keys above. Off by default. See docs/credentials-spike.md.</div>
+                            </div>
+                            <div class="checkboxContainer checkboxContainer-withDescription">
+                                <label class="emby-checkbox-label">
                                     <input id="ScanDiscogs" name="ScanDiscogs" type="checkbox" is="emby-checkbox" />
                                     <span>Use Discogs to complete record labels and artist discographies</span>
                                 </label>

--- a/Jellyfin.Plugin.MindTheGaps/Web/mindthegaps.js
+++ b/Jellyfin.Plugin.MindTheGaps/Web/mindthegaps.js
@@ -1836,6 +1836,7 @@
                     page.querySelector('#TvMazeEnabled').checked = config.TvMazeEnabled;
                     page.querySelector('#TvdbEnabled').checked = config.TvdbEnabled;
                     page.querySelector('#TvdbApiKey').value = config.TvdbApiKey || '';
+                    page.querySelector('#ReuseInstalledProviderKeys').checked = config.ReuseInstalledProviderKeys;
                     page.querySelector('#MetadataCountryCode').value = config.MetadataCountryCode || '';
                     page.querySelector('#MetadataLanguage').value = config.MetadataLanguage || '';
                     page.querySelector('#TmdbApiKey').value = config.TmdbApiKey || '';
@@ -1912,6 +1913,7 @@
                         config.TvMazeEnabled = form.querySelector('#TvMazeEnabled').checked;
                         config.TvdbEnabled = form.querySelector('#TvdbEnabled').checked;
                         config.TvdbApiKey = form.querySelector('#TvdbApiKey').value;
+                        config.ReuseInstalledProviderKeys = form.querySelector('#ReuseInstalledProviderKeys').checked;
                         config.MetadataCountryCode = form.querySelector('#MetadataCountryCode').value;
                         config.MetadataLanguage = form.querySelector('#MetadataLanguage').value;
                         config.TmdbApiKey = form.querySelector('#TmdbApiKey').value;

--- a/docs/credentials-spike.md
+++ b/docs/credentials-spike.md
@@ -1,0 +1,41 @@
+# Spike: reusing an installed plugin's provider key
+
+## Question
+
+A user who already runs the in-box TheTVDB metadata plugin has entered a TheTVDB subscriber key there. Can
+Mind the Gaps reuse that key for its TheTVDB cross-check instead of asking for it a second time?
+
+## Finding
+
+There is no supported host API for one plugin to read another plugin's secrets. A plugin's configuration is
+private to it; the host exposes no "give me plugin X's config" surface. The only available path is
+reflection: enumerate `IPluginManager.Plugins`, match the target plugin by assembly name, read its
+`Configuration` property, and read the key off that config object by property name. This is a soft dependency
+on another plugin's internals and is fragile: a renamed property, a changed type, or a disabled plugin all
+break it.
+
+## What was built
+
+`Services/InstalledPluginCredentials` does exactly that, guarded so it can never break a scan:
+
+- It targets the TheTVDB plugin only (assembly `Jellyfin.Plugin.Tvdb`) and tries a short list of key
+  property names (`SubscriberPIN`, `SubscriberPin`, `ApiKey`) in order.
+- Every reflection step is wrapped in `try`/`catch`; any failure (plugin absent, disabled, property renamed,
+  type mismatch) logs at debug and returns `null`. It never throws.
+- It is gated behind an opt-in toggle, `ReuseInstalledProviderKeys`, off by default.
+- `TvdbContentGapSource.ResolveApiKey` prefers the user's own configured key and only falls back to a
+  discovered key when ours is blank and the toggle is on. A discovery miss falls back to empty, so the source
+  simply reports itself disabled rather than erroring.
+
+## Scope and non-goals
+
+- **Trakt is intentionally not wired.** Trakt needs an OAuth client id, not a drop-in key, and its semantics
+  are murkier; it is not worth broadening this fragile surface for.
+- **TMDB does not need it.** The plugin already uses the public default key or the user's own; the durable
+  fix is upstream (let the host expose its TMDB client/key, discussion C), not more reflection.
+
+## Verdict
+
+Usable as a convenience, off by default, TheTVDB only. It stays a workaround until a supported host SPI for
+credentialed providers exists (a "providers expose a credentialed client" surface, the way
+`IExternalUrlProvider` exposes links). Keep the reflection guarded and the toggle off by default.


### PR DESCRIPTION
When the TheTVDB cross-check's own key is blank, an opt-in toggle lets the source make a best-effort read of the in-box TheTVDB plugin's configured key. There is no supported host API for reading another plugin's secrets, so InstalledPlugin- Credentials reflects into the foreign plugin's Configuration by assembly and property name, wrapped so any failure (plugin absent, disabled, renamed property) returns null and never breaks a scan. TvdbContentGapSource.ResolveApiKey prefers the user's own key and only falls back when ours is blank and the toggle is on.

Off by default, TheTVDB only; Trakt (OAuth, not a drop-in key) and TMDB (covered the supported way) are out of scope. See docs/credentials-spike.md.