### PR TITLE
Clear down a filled gap from anywhere in the report

### DIFF
--- a/Jellyfin.Plugin.MindTheGaps.Tests/GapStoreTests.cs
+++ b/Jellyfin.Plugin.MindTheGaps.Tests/GapStoreTests.cs
@@ -173,7 +173,7 @@ public class GapStoreTests
     }
 
     [Fact]
-    public void ReplaceSeriesGaps_SwapsOnlyThatSeriesContentGapsAndKeepsTheRest()
+    public void ReplaceSourceGaps_ForASeries_SwapsOnlyThatSeriesContentGapsAndKeepsTheRest()
     {
         var dir = TempDir();
         try
@@ -196,13 +196,137 @@ public class GapStoreTests
 
             // The re-check now finds only E01 for this series (E02 was fixed).
             var fresh = new GapReport { Items = new[] { SeriesGap("seriescontent:" + key + ":s01e01", key) } };
-            var updated = store.ReplaceSeriesGaps(seriesId, fresh);
+            var updated = store.ReplaceSourceGaps(key, new[] { "seriescontent:" }, fresh);
 
             Assert.Contains(updated.Items, i => i.Id == "seriescontent:" + key + ":s01e01");
             Assert.DoesNotContain(updated.Items, i => i.Id == "seriescontent:" + key + ":s01e02");
             Assert.Contains(updated.Items, i => i.Id == "seriescontent:" + otherKey + ":s01e01");
             Assert.Contains(updated.Items, i => i.Id == "movie:1");
             Assert.Equal(3, updated.TotalGaps);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void ReplaceSourceGaps_SwapsOnlyTheClaimedPrefixesForThatOwner()
+    {
+        var dir = TempDir();
+        try
+        {
+            var store = Store(dir);
+            var boxSet = Guid.NewGuid().ToString("N");
+
+            store.Save(new GapReport
+            {
+                Items = new[]
+                {
+                    SeriesGap("collection:10:1", boxSet),      // re-checked away
+                    SeriesGap("collection:10:2", boxSet),      // re-checked, still missing
+                    SeriesGap("recommendation:10:9", boxSet),  // same owner, another source: untouched
+                    SeriesGap("collection:11:1", Guid.NewGuid().ToString("N")) // another owner: untouched
+                }
+            });
+
+            var fresh = new GapReport { Items = new[] { SeriesGap("collection:10:2", boxSet) } };
+            var updated = store.ReplaceSourceGaps(boxSet, new[] { "collection:" }, fresh);
+
+            Assert.DoesNotContain(updated.Items, i => i.Id == "collection:10:1");
+            Assert.Contains(updated.Items, i => i.Id == "collection:10:2");
+            Assert.Contains(updated.Items, i => i.Id == "recommendation:10:9");
+            Assert.Contains(updated.Items, i => i.Id == "collection:11:1");
+            Assert.Equal(3, updated.TotalGaps);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void ReplaceSourceGaps_WithSeveralPrefixes_SwapsEachClaimingSourcesGaps()
+    {
+        var dir = TempDir();
+        try
+        {
+            var store = Store(dir);
+            var artist = Guid.NewGuid().ToString("N");
+
+            // An artist is claimed by both music sources at once, so a re-check swaps both prefixes.
+            store.Save(new GapReport
+            {
+                Items = new[]
+                {
+                    SeriesGap("discography:mb:1", artist),
+                    SeriesGap("discogsartist:99:1", artist),
+                    SeriesGap("artistworks:mb:1", artist)
+                }
+            });
+
+            var fresh = new GapReport { Items = new[] { SeriesGap("discography:mb:2", artist) } };
+            var updated = store.ReplaceSourceGaps(artist, new[] { "discography:", "discogsartist:" }, fresh);
+
+            Assert.DoesNotContain(updated.Items, i => i.Id == "discography:mb:1");
+            Assert.DoesNotContain(updated.Items, i => i.Id == "discogsartist:99:1");
+            Assert.Contains(updated.Items, i => i.Id == "discography:mb:2");
+            Assert.Contains(updated.Items, i => i.Id == "artistworks:mb:1");
+            Assert.Equal(2, updated.TotalGaps);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void RemoveGaps_DropsOnlyTheNamedIdsAndPreservesTheScanStamp()
+    {
+        var dir = TempDir();
+        try
+        {
+            var store = Store(dir);
+            var generated = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+            store.Save(new GapReport
+            {
+                GeneratedUtc = generated,
+                GeneratedVersion = "1.2.3.4",
+                Items = new[] { Gap("a"), Gap("b"), Gap("c") }
+            });
+
+            var removed = store.RemoveGaps(new[] { "a", "c", "never-there" });
+
+            var loaded = store.Load();
+            Assert.Equal(2, removed);
+            Assert.Single(loaded.Items);
+            Assert.Equal("b", loaded.Items[0].Id);
+            Assert.Equal(1, loaded.TotalGaps);
+
+            // A verify is a partial update, so it must not look like a fresh scan (which would clear
+            // the post-upgrade rescan nudge).
+            Assert.Equal(generated, loaded.GeneratedUtc);
+            Assert.Equal("1.2.3.4", loaded.GeneratedVersion);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void RemoveGaps_WithNoMatchingIds_LeavesTheReportAlone()
+    {
+        var dir = TempDir();
+        try
+        {
+            var store = Store(dir);
+            var report = new GapReport { TotalGaps = 1, Items = new[] { Gap("a") } };
+            store.Save(report);
+
+            Assert.Equal(0, store.RemoveGaps(new[] { "nope" }));
+            Assert.Equal(0, store.RemoveGaps(Array.Empty<string>()));
+            Assert.Same(report, store.Load());
         }
         finally
         {

--- a/Jellyfin.Plugin.MindTheGaps.Tests/GapTargetKeyTests.cs
+++ b/Jellyfin.Plugin.MindTheGaps.Tests/GapTargetKeyTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.MindTheGaps.Gaps;
+using Jellyfin.Plugin.MindTheGaps.Model;
+using Xunit;
+
+namespace Jellyfin.Plugin.MindTheGaps.Tests;
+
+public class GapTargetKeyTests
+{
+    private static GapItem Movie(string id, string tmdb, string? imdb = null)
+    {
+        var ids = new Dictionary<string, string> { ["Tmdb"] = tmdb };
+        if (imdb is not null)
+        {
+            ids["Imdb"] = imdb;
+        }
+
+        return new GapItem { Id = id, TargetKind = BaseItemKind.Movie, Name = "Mad Max 2", ProviderIds = ids };
+    }
+
+    [Fact]
+    public void MatchingIds_FindsEveryGapAboutTheSameTitle()
+    {
+        // One acquired film is a hole in its collection, a studio set, a filmography, a list, and a
+        // recommendation, each with its own id. Confirming it owned must clear all of them.
+        var report = new[]
+        {
+            Movie("collection:8945:76341", "76341"),
+            Movie("curated:studio-123:76341", "76341"),
+            Movie("filmography:movie:76341", "76341"),
+            Movie("recommendation:movie:76341", "76341"),
+            Movie("mdblist:99:76341", "76341"),
+            Movie("collection:8945:76342", "76342")   // a different film in the same collection
+        };
+
+        var matched = GapTargetKey.MatchingIds(report, new[] { report[0] });
+
+        Assert.Equal(5, matched.Count);
+        Assert.DoesNotContain("collection:8945:76342", matched);
+    }
+
+    [Fact]
+    public void MatchingIds_MatchesOnAnySharedProviderId()
+    {
+        // The background availability pass resolves extra ids onto some rows but not others, so two gaps
+        // about one film can overlap on only one provider.
+        var enriched = Movie("collection:8945:76341", "76341", "tt0082694");
+        var tmdbOnly = Movie("recommendation:movie:76341", "76341");
+        var imdbOnly = new GapItem
+        {
+            Id = "mdblist:99:tt0082694",
+            TargetKind = BaseItemKind.Movie,
+            Name = "Mad Max 2",
+            ProviderIds = new Dictionary<string, string> { ["Imdb"] = "tt0082694" }
+        };
+
+        var matched = GapTargetKey.MatchingIds(new[] { enriched, tmdbOnly, imdbOnly }, new[] { enriched });
+
+        Assert.Equal(3, matched.Count);
+    }
+
+    [Fact]
+    public void MatchingIds_FollowsProviderIdLinksTransitively()
+    {
+        // The three representations one film gets as the availability pass resolves ids onto some rows and
+        // not others. Clicking the TMDB-only row shares no key with the IMDb-only row, so they are linked
+        // only through the enriched row in the middle.
+        var tmdbOnly = Movie("collection:8945:76341", "76341");
+        var both = Movie("curated:studio-1:76341", "76341", "tt0082694");
+        var imdbOnly = new GapItem
+        {
+            Id = "mdblist:99:tt0082694",
+            TargetKind = BaseItemKind.Movie,
+            Name = "Mad Max 2",
+            ProviderIds = new Dictionary<string, string> { ["Imdb"] = "tt0082694" }
+        };
+        var unrelated = Movie("collection:8945:76342", "76342");
+
+        var matched = GapTargetKey.MatchingIds(new[] { tmdbOnly, both, imdbOnly, unrelated }, new[] { tmdbOnly });
+
+        Assert.Equal(3, matched.Count);
+        Assert.Contains("mdblist:99:tt0082694", matched, StringComparer.Ordinal);
+        Assert.DoesNotContain("collection:8945:76342", matched, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void MatchingIds_ClearingAnyRepresentation_ClearsThemAll()
+    {
+        // The closure must not depend on which row was clicked.
+        var tmdbOnly = Movie("a", "76341");
+        var both = Movie("b", "76341", "tt0082694");
+        var imdbOnly = new GapItem
+        {
+            Id = "c",
+            TargetKind = BaseItemKind.Movie,
+            Name = "Mad Max 2",
+            ProviderIds = new Dictionary<string, string> { ["Imdb"] = "tt0082694" }
+        };
+        var all = new[] { tmdbOnly, both, imdbOnly };
+
+        foreach (var clicked in all)
+        {
+            Assert.Equal(3, GapTargetKey.MatchingIds(all, new[] { clicked }).Count);
+        }
+    }
+
+    [Fact]
+    public void MatchingIds_DoesNotChainAcrossItemKinds()
+    {
+        // Transitivity must not leak between kinds: a series sharing a TMDB id with a movie is not a bridge
+        // to that series' other ids.
+        var movie = Movie("m", "1");
+        var series = new GapItem
+        {
+            Id = "s",
+            TargetKind = BaseItemKind.Series,
+            Name = "Same Number",
+            ProviderIds = new Dictionary<string, string> { ["Tmdb"] = "1", ["Imdb"] = "tt999" }
+        };
+        var otherSeries = new GapItem
+        {
+            Id = "s2",
+            TargetKind = BaseItemKind.Series,
+            Name = "Linked By Imdb",
+            ProviderIds = new Dictionary<string, string> { ["Imdb"] = "tt999" }
+        };
+
+        var matched = GapTargetKey.MatchingIds(new[] { movie, series, otherSeries }, new[] { movie });
+
+        Assert.Equal("m", Assert.Single(matched));
+    }
+
+    [Fact]
+    public void MatchingIds_DoesNotCrossItemKinds()
+    {
+        // A series and a movie can share a TMDB id; they are not the same thing.
+        var movie = Movie("filmography:movie:1", "1");
+        var series = new GapItem
+        {
+            Id = "filmography:series:1",
+            TargetKind = BaseItemKind.Series,
+            Name = "Same Number",
+            ProviderIds = new Dictionary<string, string> { ["Tmdb"] = "1" }
+        };
+
+        var matched = GapTargetKey.MatchingIds(new[] { movie, series }, new[] { movie });
+
+        Assert.Equal("filmography:movie:1", Assert.Single(matched));
+    }
+
+    [Fact]
+    public void MatchingIds_MatchesAlbumsByArtistAndTitleWhenIdsDoNotOverlap()
+    {
+        // A Discogs release and a MusicBrainz release group for one record share no provider id, so the
+        // name key is the only thing that can link them (the same fallback LibraryVerifier uses).
+        var musicBrainz = new GapItem
+        {
+            Id = "discography:mb-artist:rg-1",
+            TargetKind = BaseItemKind.MusicAlbum,
+            Name = "Kind of Blue",
+            SourceItemName = "Miles Davis",
+            ProviderIds = new Dictionary<string, string> { ["MusicBrainzReleaseGroup"] = "rg-1" }
+        };
+        var discogs = new GapItem
+        {
+            Id = "discogsartist:55:r-9",
+            TargetKind = BaseItemKind.MusicAlbum,
+            Name = "Kind of Blue",
+            SourceItemName = "Miles Davis",
+            ProviderIds = new Dictionary<string, string> { ["Discogs"] = "r-9" }
+        };
+
+        var matched = GapTargetKey.MatchingIds(new[] { musicBrainz, discogs }, new[] { musicBrainz });
+
+        Assert.Equal(2, matched.Count);
+    }
+
+    [Fact]
+    public void MatchingIds_WithNothingToMatchOn_ReturnsEmpty()
+    {
+        var idless = new GapItem { Id = "x", TargetKind = BaseItemKind.Movie, Name = "No ids" };
+
+        Assert.Empty(GapTargetKey.MatchingIds(new[] { idless }, new[] { idless }));
+        Assert.Empty(GapTargetKey.MatchingIds(new[] { Movie("a", "1") }, Enumerable.Empty<GapItem>()));
+    }
+}

--- a/Jellyfin.Plugin.MindTheGaps.Tests/TodoStoreTests.cs
+++ b/Jellyfin.Plugin.MindTheGaps.Tests/TodoStoreTests.cs
@@ -171,4 +171,77 @@ public class TodoStoreTests
             Directory.Delete(dir, true);
         }
     }
+
+    [Fact]
+    public void ReconcileDone_AppliesEveryStateAndReportsWhatChanged()
+    {
+        var dir = TempDir();
+        try
+        {
+            var store = Store(dir);
+            store.Add(new[] { Gap("a") });
+            store.Add(new[] { Gap("b") });
+            store.Add(new[] { Gap("c") });
+            store.SetDone("b", true);
+
+            // a goes done, b stays done, c stays outstanding: only a moved.
+            var changed = store.ReconcileDone(new Dictionary<string, bool>
+            {
+                ["a"] = true,
+                ["b"] = true,
+                ["c"] = false,
+                ["missing"] = true
+            });
+
+            var byId = store.Load().ToDictionary(e => e.Id, StringComparer.Ordinal);
+            Assert.Equal(1, changed);
+            Assert.True(byId["a"].Done);
+            Assert.True(byId["b"].Done);
+            Assert.False(byId["c"].Done);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void ReconcileDone_ClearsAnEntryWhoseTitleHasLeftTheLibrary()
+    {
+        var dir = TempDir();
+        try
+        {
+            var store = Store(dir);
+            store.Add(new[] { Gap("a") });
+            store.SetDone("a", true);
+
+            Assert.Equal(1, store.ReconcileDone(new Dictionary<string, bool> { ["a"] = false }));
+
+            var entry = Assert.Single(store.Load());
+            Assert.False(entry.Done);
+            Assert.Null(entry.DoneUtc);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void ReconcileDone_WithNothingToChange_ReportsZero()
+    {
+        var dir = TempDir();
+        try
+        {
+            var store = Store(dir);
+            store.Add(new[] { Gap("a") });
+
+            Assert.Equal(0, store.ReconcileDone(new Dictionary<string, bool> { ["a"] = false }));
+            Assert.Equal(0, store.ReconcileDone(new Dictionary<string, bool>()));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
 }

--- a/Jellyfin.Plugin.MindTheGaps/Api/GapsController.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Api/GapsController.cs
@@ -30,7 +30,8 @@ public class GapsController : ControllerBase
     private readonly ExploreRunner _exploreRunner;
     private readonly ScanCursorStore _cursors;
     private readonly ExploreRegistry _explore;
-    private readonly GapEngine _engine;
+    private readonly LibraryVerifier _verifier;
+    private readonly RecheckRunner _recheckRunner;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GapsController"/> class.
@@ -40,15 +41,17 @@ public class GapsController : ControllerBase
     /// <param name="exploreRunner">The background ad-hoc explore runner.</param>
     /// <param name="cursors">The scan-rotation cursor store.</param>
     /// <param name="explore">The explore-kind registry, backing the curated type-ahead, id resolution, and kinds list.</param>
-    /// <param name="engine">The gap engine, for a targeted single-series re-check.</param>
-    public GapsController(GapStore store, GapScanRunner scanRunner, ExploreRunner exploreRunner, ScanCursorStore cursors, ExploreRegistry explore, GapEngine engine)
+    /// <param name="verifier">The library verifier, for clearing gaps the library has since been given.</param>
+    /// <param name="recheckRunner">The background bulk re-check runner.</param>
+    public GapsController(GapStore store, GapScanRunner scanRunner, ExploreRunner exploreRunner, ScanCursorStore cursors, ExploreRegistry explore, LibraryVerifier verifier, RecheckRunner recheckRunner)
     {
         _store = store;
         _scanRunner = scanRunner;
         _exploreRunner = exploreRunner;
         _cursors = cursors;
         _explore = explore;
-        _engine = engine;
+        _verifier = verifier;
+        _recheckRunner = recheckRunner;
     }
 
     /// <summary>
@@ -132,26 +135,116 @@ public class GapsController : ControllerBase
     }
 
     /// <summary>
-    /// Re-checks one owned series for missing episodes and replaces just that series' gaps in the report, so
-    /// a metadata fix can be verified without a full rescan. Runs the series-content sources for the one
-    /// series (the library reader plus the enabled cross-checks), then returns the gap count now standing.
+    /// Re-checks a batch of owning items in the background, for the dashboard's per-heading re-check ("every
+    /// studio", "every collection"). Runs in the background because a heading can cover hundreds of sets;
+    /// poll <see cref="GetRecheckStatus"/> and reload the report when it finishes. The ownership index is
+    /// built once for the whole batch, so this is cheaper than calling <see cref="RecheckSources"/> per item.
     /// </summary>
-    /// <param name="seriesId">The owned series' id (its Jellyfin GUID).</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The number of missing-episode gaps the series now has.</returns>
-    [HttpPost("RecheckSeries")]
+    /// <param name="ownerIds">The owning library items' ids (Jellyfin GUIDs). Ids no enabled source claims are skipped.</param>
+    /// <returns>The run status, with Started indicating whether this call kicked one off.</returns>
+    [HttpPost("RecheckSources")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<int>> RecheckSeries([FromQuery] string? seriesId, CancellationToken cancellationToken)
+    public ActionResult<RecheckStatus> RecheckSources([FromBody] IReadOnlyList<string>? ownerIds)
     {
-        if (!Guid.TryParse(seriesId, out var id))
+        if (ownerIds is null || ownerIds.Count == 0)
         {
-            return BadRequest("A seriesId is required.");
+            return BadRequest("At least one ownerId is required.");
         }
 
-        var recheck = await _engine.RecheckSeriesAsync(id, cancellationToken).ConfigureAwait(false);
-        _store.ReplaceSeriesGaps(id, recheck);
-        return recheck.Items.Count;
+        var ids = new List<Guid>(ownerIds.Count);
+        foreach (var raw in ownerIds)
+        {
+            if (Guid.TryParse(raw, out var id))
+            {
+                ids.Add(id);
+            }
+        }
+
+        if (ids.Count == 0)
+        {
+            return BadRequest("No ownerId parsed as a library item id.");
+        }
+
+        var started = _recheckRunner.TryStart(ids);
+        return RecheckStatusNow(started);
+    }
+
+    /// <summary>
+    /// Gets whether a bulk re-check is running, and how far through it is.
+    /// </summary>
+    /// <returns>The bulk re-check status.</returns>
+    [HttpGet("RecheckStatus")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult<RecheckStatus> GetRecheckStatus() => RecheckStatusNow(false);
+
+    private RecheckStatus RecheckStatusNow(bool started) => new()
+    {
+        Running = _recheckRunner.IsRunning,
+        Started = started,
+        Progress = _recheckRunner.Progress,
+        Total = _recheckRunner.Total,
+        Done = _recheckRunner.Done
+    };
+
+    /// <summary>
+    /// Verifies gaps against the library and drops the ones it now holds, so a filled gap can be cleared from
+    /// the report without a rescan. Purely local: it asks no provider, and so clears filled gaps but does not
+    /// discover new ones (see <see cref="RecheckSources"/> for that). Works for every domain, pattern, and kind.
+    /// </summary>
+    /// <param name="ids">The gap ids to check. Ids the report no longer holds are skipped.</param>
+    /// <returns>How many were checked, how many were owned, and the ids removed.</returns>
+    [HttpPost("Verify")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public ActionResult<VerifyResult> Verify([FromBody] IReadOnlyList<string>? ids)
+    {
+        if (ids is null || ids.Count == 0)
+        {
+            return BadRequest("At least one gap id is required.");
+        }
+
+        // Rehydrate every gap server-side by id, as every other endpoint does: the client sends ids, never
+        // gap bodies, so a stale or forged row cannot decide what gets dropped. One snapshot, indexed once
+        // and reused for the sweep below, because a per-id scan of the whole report would be quadratic on a
+        // large filtered tab before a single library query had run.
+        var snapshot = _store.LoadSnapshot().Items;
+        var byId = new Dictionary<string, GapItem>(snapshot.Count, StringComparer.Ordinal);
+        foreach (var item in snapshot)
+        {
+            byId[item.Id] = item;
+        }
+
+        var checkedCount = 0;
+        var owned = new List<GapItem>();
+        foreach (var id in ids)
+        {
+            if (!byId.TryGetValue(id, out var gap))
+            {
+                continue;
+            }
+
+            checkedCount++;
+            if (_verifier.Owns(gap))
+            {
+                owned.Add(gap);
+            }
+        }
+
+        // One acquired title is normally several gaps (its collection, a studio set, a filmography, a
+        // recommendation), each with its own id from its own source. Having confirmed the title is in the
+        // library, drop every gap about it, not just the row that was clicked, so it leaves all the tabs it
+        // was on at once rather than lingering until each is verified separately.
+        var removedIds = GapTargetKey.MatchingIds(snapshot, owned);
+        var removed = _store.RemoveGaps(removedIds);
+
+        return new VerifyResult
+        {
+            Checked = checkedCount,
+            Owned = owned.Count,
+            Removed = removed,
+            RemovedIds = removedIds
+        };
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.MindTheGaps/Api/TodoController.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Api/TodoController.cs
@@ -26,19 +26,19 @@ public class TodoController : ControllerBase
 {
     private readonly GapStore _store;
     private readonly TodoStore _todo;
-    private readonly ILibraryManager _libraryManager;
+    private readonly LibraryVerifier _verifier;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TodoController"/> class.
     /// </summary>
     /// <param name="store">The gap store, to snapshot the report when adding entries.</param>
     /// <param name="todo">The personal todo-list store.</param>
-    /// <param name="libraryManager">The library manager, used to verify a todo entry against the library.</param>
-    public TodoController(GapStore store, TodoStore todo, ILibraryManager libraryManager)
+    /// <param name="verifier">The library verifier, so a todo entry is checked exactly as a report row is.</param>
+    public TodoController(GapStore store, TodoStore todo, LibraryVerifier verifier)
     {
         _store = store;
         _todo = todo;
-        _libraryManager = libraryManager;
+        _verifier = verifier;
     }
 
     /// <summary>
@@ -124,39 +124,48 @@ public class TodoController : ControllerBase
         return new TodoVerifyResult { Owned = owned, Entry = updated };
     }
 
-    // Whether the library owns a real (non-virtual) item of the entry's kind carrying any of its provider
-    // ids. A focused query (the kind, real items only, any of the ids) keeps the lookup cheap rather than
-    // building a whole ownership index for a single check.
-    private bool LibraryOwns(TodoEntry entry)
+    /// <summary>
+    /// Verifies the whole todo list against the library in one pass, marking each entry done or not to match.
+    /// The bulk form of <see cref="VerifyTodo"/>, for the popup's "check everything" action and for the
+    /// verify the Markdown export runs before writing, so an exported checklist is true when it is written.
+    /// </summary>
+    /// <returns>How many entries were checked and how many the library now holds, with the updated list.</returns>
+    [HttpPost("Todo/VerifyAll")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult<TodoVerifyAllResult> VerifyAllTodo()
     {
-        if (entry.ProviderIds.Count == 0
-            || !Enum.TryParse<BaseItemKind>(entry.TargetKindName, ignoreCase: false, out var kind))
-        {
-            return false;
-        }
+        var entries = _todo.Load();
+        var owned = 0;
 
-        var hasAny = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var pair in entry.ProviderIds)
+        // Stamp both ways: an entry marked done whose file has since left the library becomes outstanding
+        // again, so the list keeps telling the truth rather than only ever accumulating ticks. Collected
+        // first and applied in one write, since the store flushes the whole file per change.
+        var states = new Dictionary<string, bool>(entries.Count, StringComparer.Ordinal);
+        foreach (var entry in entries)
         {
-            if (!string.IsNullOrEmpty(pair.Value))
+            var has = LibraryOwns(entry);
+            if (has)
             {
-                hasAny[pair.Key] = pair.Value;
+                owned++;
             }
+
+            states[entry.Id] = has;
         }
 
-        if (hasAny.Count == 0)
-        {
-            return false;
-        }
+        _todo.ReconcileDone(states);
 
-        var matches = _libraryManager.GetItemList(new InternalItemsQuery
+        return new TodoVerifyAllResult
         {
-            IncludeItemTypes = new[] { kind },
-            IsVirtualItem = false,
-            HasAnyProviderId = hasAny,
-            Recursive = true
-        });
-
-        return matches.Count > 0;
+            Checked = entries.Count,
+            Owned = owned,
+            Items = _todo.Load()
+        };
     }
+
+    // Whether the library holds this entry, decided by the same rules the report's verify uses (a shared
+    // provider id, or for an album the artist-and-title name match). A todo entry is a gap the user copied
+    // aside, so the two must not be able to disagree about whether it has been filled.
+    private bool LibraryOwns(TodoEntry entry)
+        => Enum.TryParse<BaseItemKind>(entry.TargetKindName, ignoreCase: false, out var kind)
+            && _verifier.Owns(kind, entry.ProviderIds, entry.Creator, entry.Name);
 }

--- a/Jellyfin.Plugin.MindTheGaps/Gaps/GapEngine.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Gaps/GapEngine.cs
@@ -24,6 +24,10 @@ namespace Jellyfin.Plugin.MindTheGaps.Gaps;
 /// </summary>
 public sealed class GapEngine
 {
+    // Every series-content gap carries this prefix, so a series re-check swaps exactly those and leaves a
+    // recommendation the series happens to seed alone.
+    private static readonly string[] SeriesPrefixes = ["seriescontent:"];
+
     private readonly ILibraryManager _libraryManager;
     private readonly IEnumerable<IGapSource> _sources;
     private readonly ExploreRegistry _explore;
@@ -382,74 +386,209 @@ public sealed class GapEngine
     }
 
     /// <summary>
-    /// Re-checks one owned series for missing episodes by running the enabled series-content sources for
-    /// just that series, so the dashboard can verify a fix without a full rescan. The result is meant to
-    /// replace that series' gaps in the report (see <see cref="GapStore.ReplaceSeriesGaps"/>).
+    /// Re-checks a batch of owning items and swaps each one's gaps into the report as it goes, so the
+    /// dashboard can re-check every set under a heading ("Studios", "Collections and franchises") in one
+    /// pass. The ownership index is built once for the whole batch rather than per item, which is what makes
+    /// this cheaper than re-checking each item on its own.
     /// </summary>
-    /// <param name="seriesId">The owned series to re-check.</param>
+    /// <param name="ownerIds">The owning library items to re-check.</param>
+    /// <param name="progress">Progress sink (0-100).</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A report holding just that series' current missing-episode gaps.</returns>
-    public async Task<GapReport> RecheckSeriesAsync(Guid seriesId, CancellationToken cancellationToken)
+    /// <returns>How many owning items were actually re-checked (those with no claiming source are skipped).</returns>
+    public async Task<int> RecheckManyAsync(IReadOnlyList<Guid> ownerIds, IProgress<double>? progress, CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(ownerIds);
+
         var config = Plugin.RequireConfiguration();
-        var gaps = new List<GapItem>();
-        var series = _libraryManager.GetItemById(seriesId);
-        if (series is not null)
+
+        // Resolve and claim first, so the one ownership index covers every kind the batch will diff against.
+        // A series is claimed by no set source; it goes through the series-content sources instead, so a
+        // "re-check everything under this heading" works on the Shows tab as well as the Movies one.
+        var work = new List<(BaseItem Owner, List<ISetContentSource> Claimants)>(ownerIds.Count);
+        foreach (var ownerId in ownerIds)
         {
-            // The series-content sources read the library directly, so an empty ownership index is enough.
-            var context = new GapScanContext(config, BuildOwnershipIndex([]));
-            var byId = new Dictionary<string, GapItem>(StringComparer.Ordinal);
-
-            foreach (var source in _sources.OfType<ISeriesContentSource>())
+            var owner = _libraryManager.GetItemById(ownerId);
+            if (owner is null)
             {
-                if (!((IGapSource)source).IsEnabled(config))
-                {
-                    continue;
-                }
-
-                cancellationToken.ThrowIfCancellationRequested();
-
-                IReadOnlyList<GapItem> found;
-                try
-                {
-                    found = await source.CheckSeriesAsync(series, context, cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception ex) when (ex is not OperationCanceledException)
-                {
-                    // One cross-check being unreachable must not abort the re-check; the others still count.
-                    _logger.LogWarning(ex, "Re-check: {Source} failed for {Series}", ((IGapSource)source).Name, series.Name);
-                    continue;
-                }
-
-                foreach (var gap in found)
-                {
-                    if (byId.TryGetValue(gap.Id, out var existing))
-                    {
-                        MergeDuplicateSource(existing, gap);
-                    }
-                    else
-                    {
-                        byId[gap.Id] = gap;
-                        gaps.Add(gap);
-                    }
-                }
+                continue;
             }
 
-            // Re-adopt the external ids and "where to watch" a prior pass resolved for these gaps, and let the
-            // host's external-url providers contribute links, exactly as a full scan and an explore do.
-            CarryForward(gaps);
-            _externalLinks.Enrich(gaps);
-
-            _logger.LogInformation("Re-check: {Series} has {Count} missing-episode gap(s)", series.Name, gaps.Count);
+            var claimants = Claimants(owner, config);
+            if (claimants.Count > 0 || owner.GetBaseItemKind() == BaseItemKind.Series)
+            {
+                work.Add((owner, claimants));
+            }
         }
 
-        return new GapReport
+        if (work.Count == 0)
         {
-            GeneratedUtc = DateTime.UtcNow,
-            GeneratedVersion = Plugin.Instance?.Version?.ToString() ?? string.Empty,
-            TotalGaps = gaps.Count,
-            Items = gaps
-        };
+            _logger.LogInformation("Bulk re-check: nothing to do; no enabled source claims any of the {Count} item(s)", ownerIds.Count);
+            return 0;
+        }
+
+        var context = new GapScanContext(config, BuildOwnershipIndex(OwnedKindsOf(work.SelectMany(w => w.Claimants))));
+
+        var done = 0;
+        foreach (var (owner, claimants) in work)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            List<GapItem> gaps;
+            IReadOnlyCollection<string> prefixes;
+            if (claimants.Count > 0)
+            {
+                (gaps, prefixes) = await RunClaimantsAsync(owner, claimants, context, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                gaps = await RunSeriesSourcesAsync(owner, config, context, cancellationToken).ConfigureAwait(false);
+                prefixes = SeriesPrefixes;
+            }
+
+            // Swap each item in as it finishes rather than at the end, so a cancelled or failed batch still
+            // leaves the items it got through up to date.
+            _store.ReplaceSourceGaps(
+                owner.Id.ToString("N", CultureInfo.InvariantCulture),
+                prefixes,
+                new GapReport { TotalGaps = gaps.Count, Items = gaps });
+
+            done++;
+            progress?.Report((double)done / work.Count * 100.0);
+        }
+
+        _logger.LogInformation("Bulk re-check: re-checked {Done} of {Asked} item(s)", done, ownerIds.Count);
+        return done;
+    }
+
+    // The enabled set sources that produce gaps for this owning item. Empty for an item no source handles
+    // (a Person filmography, a recommendation seed), which is what makes a mis-aimed re-check a no-op
+    // rather than a swap that wipes the item's gaps.
+    private List<ISetContentSource> Claimants(BaseItem? owner, PluginConfiguration config)
+        => owner is null
+            ? []
+            : _sources.OfType<ISetContentSource>()
+                .Where(s => ((IGapSource)s).IsEnabled(config) && s.Claims(owner))
+                .ToList();
+
+    private static BaseItemKind[] OwnedKindsOf(IEnumerable<ISetContentSource> sources)
+        => sources.SelectMany(s => ((IGapSource)s).OwnedKinds).Distinct().ToArray();
+
+    // Runs the enabled series-content sources for one owned series, de-duping across them and carrying prior
+    // enrichment forward. Shared by the single-series re-check and the bulk one.
+    private async Task<List<GapItem>> RunSeriesSourcesAsync(
+        BaseItem series,
+        PluginConfiguration config,
+        GapScanContext context,
+        CancellationToken cancellationToken)
+    {
+        var gaps = new List<GapItem>();
+        var byId = new Dictionary<string, GapItem>(StringComparer.Ordinal);
+
+        foreach (var source in _sources.OfType<ISeriesContentSource>())
+        {
+            if (!((IGapSource)source).IsEnabled(config))
+            {
+                continue;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            IReadOnlyList<GapItem> found;
+            try
+            {
+                found = await source.CheckSeriesAsync(series, context, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // One cross-check being unreachable must not abort the re-check; the others still count.
+                _logger.LogWarning(ex, "Re-check: {Source} failed for {Series}", ((IGapSource)source).Name, series.Name);
+                continue;
+            }
+
+            foreach (var gap in found)
+            {
+                if (byId.TryGetValue(gap.Id, out var existing))
+                {
+                    MergeDuplicateSource(existing, gap);
+                }
+                else
+                {
+                    byId[gap.Id] = gap;
+                    gaps.Add(gap);
+                }
+            }
+        }
+
+        // Re-adopt the external ids and "where to watch" a prior pass resolved for these gaps, and let the
+        // host's external-url providers contribute links, exactly as a full scan and an explore do.
+        CarryForward(gaps);
+        _externalLinks.Enrich(gaps);
+
+        _logger.LogInformation("Re-check: {Series} has {Count} missing-episode gap(s)", series.Name, gaps.Count);
+        return gaps;
+    }
+
+    // Runs every claiming source for one owning item, de-duping across them and carrying prior enrichment
+    // forward, exactly as a scan and an explore do. Returns the gaps and the id prefixes to swap out.
+    private async Task<(List<GapItem> Gaps, HashSet<string> Prefixes)> RunClaimantsAsync(
+        BaseItem owner,
+        List<ISetContentSource> claimants,
+        GapScanContext context,
+        CancellationToken cancellationToken)
+    {
+        var gaps = new List<GapItem>();
+        var prefixes = new HashSet<string>(StringComparer.Ordinal);
+        var byId = new Dictionary<string, GapItem>(StringComparer.Ordinal);
+
+        foreach (var source in claimants)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            IReadOnlyList<GapItem>? found;
+            try
+            {
+                found = await source.CheckOneAsync(owner, context, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // One provider being unreachable must not abort the re-check; the others still count.
+                _logger.LogWarning(ex, "Re-check: {Source} failed for {Owner}", ((IGapSource)source).Name, owner.Name);
+                found = null;
+            }
+
+            // A source only claims its prefix when it actually answered. Claiming it after a failure would
+            // hand ReplaceSourceGaps an empty result to swap in, deleting this owner's real gaps because a
+            // provider happened to be down.
+            if (found is null)
+            {
+                _logger.LogInformation(
+                    "Re-check: {Source} could not determine {Owner}; leaving its existing gaps in place",
+                    ((IGapSource)source).Name,
+                    owner.Name);
+                continue;
+            }
+
+            prefixes.Add(source.GapIdPrefix);
+
+            foreach (var gap in found)
+            {
+                if (byId.TryGetValue(gap.Id, out var existing))
+                {
+                    MergeDuplicateSource(existing, gap);
+                }
+                else
+                {
+                    byId[gap.Id] = gap;
+                    gaps.Add(gap);
+                }
+            }
+        }
+
+        CarryForward(gaps);
+        _externalLinks.Enrich(gaps);
+
+        _logger.LogInformation("Re-check: {Owner} has {Count} gap(s) across {Sources} source(s)", owner.Name, gaps.Count, claimants.Count);
+        return (gaps, prefixes);
     }
 
     // Carry prior gaps of one capped pattern forward across scans so its coverage accumulates: a gap that
@@ -683,7 +822,7 @@ public sealed class GapEngine
             return;
         }
 
-        var priorById = new Dictionary<string, GapItem>(StringComparer.Ordinal);
+        var priorById = new Dictionary<string, GapItem>(prior.Count, StringComparer.Ordinal);
         foreach (var item in prior)
         {
             priorById[item.Id] = item;

--- a/Jellyfin.Plugin.MindTheGaps/Gaps/GapStore.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Gaps/GapStore.cs
@@ -226,19 +226,74 @@ public sealed class GapStore
     }
 
     /// <summary>
-    /// Replaces a single series' content gaps with a fresh re-check and saves, leaving every other gap
-    /// untouched. Used by the per-series re-check so a metadata fix can be verified without a full rescan;
+    /// Removes the gaps with the given ids and saves, leaving every other gap untouched. Backs the report's
+    /// verify actions, which drop the rows the library has since been given. The report's scan time and
+    /// version are preserved (a verify is a partial update, not a new scan).
+    /// </summary>
+    /// <param name="ids">The gap ids to drop.</param>
+    /// <returns>The number of gaps removed.</returns>
+    public int RemoveGaps(IEnumerable<string> ids)
+    {
+        ArgumentNullException.ThrowIfNull(ids);
+
+        var drop = new HashSet<string>(ids, StringComparer.Ordinal);
+        if (drop.Count == 0)
+        {
+            return 0;
+        }
+
+        lock (_lock)
+        {
+            var current = Load();
+            var kept = new List<GapItem>(current.Items.Count);
+            var removed = 0;
+            foreach (var item in current.Items)
+            {
+                if (drop.Contains(item.Id))
+                {
+                    removed++;
+                    continue;
+                }
+
+                kept.Add(item);
+            }
+
+            if (removed == 0)
+            {
+                return 0;
+            }
+
+            var report = new GapReport
+            {
+                GeneratedUtc = current.GeneratedUtc,
+                GeneratedVersion = current.GeneratedVersion,
+                TotalGaps = kept.Count,
+                Items = kept
+            };
+            _cached = report;
+            Flush(report);
+            return removed;
+        }
+    }
+
+    /// <summary>
+    /// Replaces one owning item's gaps with a fresh re-check and saves, leaving every other gap untouched.
+    /// Used by the per-source re-check so a fix or an acquisition can be verified without a full rescan;
     /// unlike an additive merge, this also drops gaps the fix resolved. The report's scan time and version
     /// are preserved (a re-check is a partial update, not a new scan).
     /// </summary>
-    /// <param name="seriesId">The owned series whose episode gaps are being replaced.</param>
-    /// <param name="recheck">The freshly computed gaps for that series.</param>
+    /// <param name="sourceItemId">The owning item whose gaps are being replaced.</param>
+    /// <param name="idPrefixes">
+    /// The gap-id prefixes the re-checking sources produce. Only gaps carrying both this owning item and one
+    /// of these prefixes are swapped, so a re-check of (say) a collection cannot disturb a recommendation or
+    /// a filmography entry the same owning item also seeded.
+    /// </param>
+    /// <param name="recheck">The freshly computed gaps for that owning item.</param>
     /// <returns>The updated report.</returns>
-    public GapReport ReplaceSeriesGaps(Guid seriesId, GapReport recheck)
+    public GapReport ReplaceSourceGaps(string sourceItemId, IReadOnlyCollection<string> idPrefixes, GapReport recheck)
     {
+        ArgumentNullException.ThrowIfNull(idPrefixes);
         ArgumentNullException.ThrowIfNull(recheck);
-
-        var seriesKey = seriesId.ToString("N", CultureInfo.InvariantCulture);
 
         lock (_lock)
         {
@@ -246,11 +301,7 @@ public sealed class GapStore
             var kept = new List<GapItem>(current.Items.Count + recheck.Items.Count);
             foreach (var item in current.Items)
             {
-                // A series' content gaps all carry the series as their source and a "seriescontent:" id; drop
-                // exactly those (the prefix avoids touching a recommendation the series happens to seed).
-                var isSeriesContent = string.Equals(item.SourceItemId, seriesKey, StringComparison.Ordinal)
-                    && item.Id.StartsWith("seriescontent:", StringComparison.Ordinal);
-                if (!isSeriesContent)
+                if (!IsReplaced(item, sourceItemId, idPrefixes))
                 {
                     kept.Add(item);
                 }
@@ -269,6 +320,24 @@ public sealed class GapStore
             Flush(report);
             return report;
         }
+    }
+
+    private static bool IsReplaced(GapItem item, string sourceItemId, IReadOnlyCollection<string> idPrefixes)
+    {
+        if (!string.Equals(item.SourceItemId, sourceItemId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        foreach (var prefix in idPrefixes)
+        {
+            if (item.Id.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // Keep an ad-hoc re-run of the same source from discarding a "where to watch" result the background

--- a/Jellyfin.Plugin.MindTheGaps/Gaps/GapTargetKey.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Gaps/GapTargetKey.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.MindTheGaps.Model;
+
+namespace Jellyfin.Plugin.MindTheGaps.Gaps;
+
+/// <summary>
+/// The identity of the thing a gap is about, as opposed to <see cref="GapItem.Id"/>, which identifies the
+/// gap. One missing title is normally several gaps: Mad Max 2 absent from the library is a hole in its
+/// collection, in a studio set, in its director's filmography, and a recommendation, each with its own id
+/// from its own source. Acquiring the film fills all of them at once, so the report's verify uses these keys
+/// to drop every gap about a title it just confirmed you own, not only the row that was clicked.
+/// </summary>
+/// <remarks>
+/// Keys are built the same way <see cref="OwnershipIndex"/> keys the library, so "the same title" means here
+/// exactly what it means when a source decides you own something: a shared provider id under the same item
+/// kind, or for an album the artist-and-title name key, which is what matches a Discogs release against a
+/// MusicBrainz-tagged one.
+/// </remarks>
+internal static class GapTargetKey
+{
+    /// <summary>
+    /// Builds the identity keys for a gap. A gap carrying several provider ids yields one key per id, so two
+    /// gaps match when they agree on any single provider, which is what lets a TMDB-only row match one that
+    /// has since had its IMDb id resolved.
+    /// </summary>
+    /// <param name="gap">The gap.</param>
+    /// <returns>Its identity keys, empty when it carries nothing to match on.</returns>
+    public static IEnumerable<string> For(GapItem gap)
+    {
+        if (gap is null)
+        {
+            yield break;
+        }
+
+        foreach (var pair in gap.ProviderIds)
+        {
+            if (!string.IsNullOrEmpty(pair.Value))
+            {
+                yield return OwnershipIndex.MakeKey(gap.TargetKind, pair.Key, pair.Value);
+            }
+        }
+
+        // The album name fallback, matching LibraryVerifier: album sources often share no provider id, so
+        // without this a Discogs row would survive clearing the MusicBrainz one for the same record.
+        if (gap.TargetKind == BaseItemKind.MusicAlbum && !string.IsNullOrEmpty(gap.Name))
+        {
+            yield return OwnershipIndex.MakeKey(
+                gap.TargetKind,
+                OwnershipIndex.NameKeyProvider,
+                OwnershipIndex.NameKey(gap.SourceItemName, gap.Name));
+        }
+    }
+
+    /// <summary>
+    /// Finds every gap in a report that is about one of the given titles, including the titles themselves.
+    /// </summary>
+    /// <remarks>
+    /// Matching is transitive, because a title's rows do not all carry the same ids: the background pass
+    /// resolves an IMDb id onto some and not others. A TMDB-only row, a TMDB-and-IMDb row, and an IMDb-only
+    /// row are one film, but the first and last share no key directly. So this walks the graph of gaps and
+    /// the ids they share, which makes clearing any one of them clear all of them rather than only the ones
+    /// the clicked row happened to overlap. Ids are returned in the order the walk reaches them, not in
+    /// report order.
+    /// </remarks>
+    /// <param name="items">The report's gaps. Taken as a collection so the index can be sized up front.</param>
+    /// <param name="targets">The gaps whose titles have been confirmed owned.</param>
+    /// <returns>The ids of every gap about those titles.</returns>
+    public static IReadOnlyList<string> MatchingIds(IReadOnlyCollection<GapItem> items, IEnumerable<GapItem> targets)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        ArgumentNullException.ThrowIfNull(targets);
+
+        // Invert the report once, key to the gaps carrying it. The walk below then follows keys to gaps and
+        // on to those gaps' other keys, so each key and each gap is visited at most once; matching by
+        // re-scanning every gap on each pass would cost a full sweep per link in the chain.
+        // Sized by the gap count: most gaps carry one or two ids, so this lands within a growth step or
+        // two of the real key count rather than resizing its way up from nothing on a large report.
+        var byKey = new Dictionary<string, List<GapItem>>(items.Count, StringComparer.Ordinal);
+        foreach (var item in items)
+        {
+            foreach (var key in For(item))
+            {
+                if (!byKey.TryGetValue(key, out var carriers))
+                {
+                    carriers = [];
+                    byKey[key] = carriers;
+                }
+
+                carriers.Add(item);
+            }
+        }
+
+        // Seed the walk with the confirmed titles' own keys.
+        var pending = new Queue<string>();
+        var seenKeys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var target in targets)
+        {
+            foreach (var key in For(target))
+            {
+                if (seenKeys.Add(key))
+                {
+                    pending.Enqueue(key);
+                }
+            }
+        }
+
+        // Deliberately not presized: what comes back is one title's rows, a handful, however big the report
+        // is. Sizing these to the report would allocate for tens of thousands to hold five.
+        var matched = new List<string>();
+        var takenIds = new HashSet<string>(StringComparer.Ordinal);
+        while (pending.Count > 0)
+        {
+            if (!byKey.TryGetValue(pending.Dequeue(), out var carriers))
+            {
+                continue;
+            }
+
+            foreach (var item in carriers)
+            {
+                if (!takenIds.Add(item.Id))
+                {
+                    continue;
+                }
+
+                matched.Add(item.Id);
+
+                // Adopt this gap's other ids, which is what reaches a row sharing only one of them.
+                foreach (var other in For(item))
+                {
+                    if (seenKeys.Add(other))
+                    {
+                        pending.Enqueue(other);
+                    }
+                }
+            }
+        }
+
+        return matched;
+    }
+}

--- a/Jellyfin.Plugin.MindTheGaps/Gaps/ISetContentSource.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Gaps/ISetContentSource.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.MindTheGaps.Model;
+using MediaBrowser.Controller.Entities;
+
+namespace Jellyfin.Plugin.MindTheGaps.Gaps;
+
+/// <summary>
+/// A source that can re-run for one owning library item on its own, so the report can re-check a single
+/// collection, artist, or author the way <see cref="ISeriesContentSource"/> re-checks a single series
+/// (ADR-0013). Unlike the report's verify action, which only drops what the library has since been given,
+/// a re-check asks the provider again and so also picks up members added to the set since the last scan.
+/// </summary>
+/// <remarks>
+/// Implemented by the sources whose per-entity step is a bounded, cached provider call: the TMDB
+/// collections, the music artist walks, and the book bibliography. The filmography and recommendation
+/// sources stay out deliberately, since re-running one of those needs a library-wide ownership index.
+/// </remarks>
+internal interface ISetContentSource
+{
+    /// <summary>
+    /// Gets the prefix this source stamps on the gap ids it produces, so a re-check swaps out exactly its
+    /// own gaps for the owning item and leaves another source's alone (see
+    /// <see cref="GapStore.ReplaceSourceGaps"/>).
+    /// </summary>
+    string GapIdPrefix { get; }
+
+    /// <summary>
+    /// Determines, without any network call, whether this source is the one that produces gaps for the given
+    /// owning library item (a BoxSet for the collections source, a MusicArtist for the music sources, ...).
+    /// </summary>
+    /// <param name="owner">The owning library item the report is re-checking.</param>
+    /// <returns><see langword="true"/> when this source should be re-run for that item.</returns>
+    bool Claims(BaseItem owner);
+
+    /// <summary>
+    /// Re-checks one owning item for what it is still missing.
+    /// </summary>
+    /// <param name="owner">The owning library item.</param>
+    /// <param name="context">The scan context (config and ownership).</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>
+    /// That item's current gaps, empty when it is genuinely missing nothing, or <see langword="null"/> when
+    /// the answer could not be determined (the provider failed, or the item carries no id to resolve by).
+    /// The distinction matters: a re-check replaces the item's gaps, so returning an empty list for a failed
+    /// lookup would delete a collection's real gaps on a transient outage. Null means "leave them alone".
+    /// </returns>
+    Task<IReadOnlyList<GapItem>?> CheckOneAsync(BaseItem owner, GapScanContext context, CancellationToken cancellationToken);
+}

--- a/Jellyfin.Plugin.MindTheGaps/Gaps/LibraryVerifier.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Gaps/LibraryVerifier.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.MindTheGaps.Model;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Library;
+
+namespace Jellyfin.Plugin.MindTheGaps.Gaps;
+
+/// <summary>
+/// Answers "does the library hold this one gap now?" without building a whole <see cref="OwnershipIndex"/>.
+/// Backs the report's verify actions, which run inside the request and so must stay cheap: each check is a
+/// focused, provider-id-indexed query rather than the library-wide read a scan does.
+/// </summary>
+public sealed class LibraryVerifier
+{
+    private readonly ILibraryManager _libraryManager;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LibraryVerifier"/> class.
+    /// </summary>
+    /// <param name="libraryManager">The library manager.</param>
+    public LibraryVerifier(ILibraryManager libraryManager)
+    {
+        _libraryManager = libraryManager;
+    }
+
+    /// <summary>
+    /// Determines whether the library now holds a real (non-virtual) item answering this gap, by the same
+    /// rules a scan uses: any shared provider id, or for an album the artist-and-title name match.
+    /// </summary>
+    /// <param name="gap">The gap to check.</param>
+    /// <returns><see langword="true"/> if the gap has been filled.</returns>
+    public bool Owns(GapItem gap)
+    {
+        ArgumentNullException.ThrowIfNull(gap);
+
+        return Owns(gap.TargetKind, gap.ProviderIds, gap.SourceItemName, gap.Name);
+    }
+
+    /// <summary>
+    /// Determines whether the library now holds a real (non-virtual) item answering these details, for a
+    /// caller that has the parts rather than a <see cref="GapItem"/> (a todo entry, which is a gap the user
+    /// copied aside and which must answer this question the same way the report does).
+    /// </summary>
+    /// <param name="kind">The item kind.</param>
+    /// <param name="providerIds">The candidate's provider ids.</param>
+    /// <param name="artist">The album artist, for the name fallback. Ignored for other kinds.</param>
+    /// <param name="title">The title.</param>
+    /// <returns><see langword="true"/> if the library holds it.</returns>
+    public bool Owns(BaseItemKind kind, IReadOnlyDictionary<string, string> providerIds, string? artist, string? title)
+    {
+        ArgumentNullException.ThrowIfNull(providerIds);
+
+        return OwnsByProviderId(kind, providerIds) || OwnsByName(kind, artist, title);
+    }
+
+    private bool OwnsByProviderId(BaseItemKind kind, IReadOnlyDictionary<string, string> providerIds)
+    {
+        var hasAny = new Dictionary<string, string>(providerIds.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in providerIds)
+        {
+            if (!string.IsNullOrEmpty(pair.Value))
+            {
+                hasAny[pair.Key] = pair.Value;
+            }
+        }
+
+        if (hasAny.Count == 0)
+        {
+            return false;
+        }
+
+        return _libraryManager.GetItemList(new InternalItemsQuery
+        {
+            IncludeItemTypes = new[] { kind },
+            IsVirtualItem = false,
+            HasAnyProviderId = hasAny,
+            Limit = 1,
+            Recursive = true
+        }).Count > 0;
+    }
+
+    // The name fallback, for an album whose provider ids do not overlap the library's (a Discogs release
+    // against a MusicBrainz-tagged album). Deliberately album-only, matching what the scan's ownership index
+    // name-keys and what GapEngine's carry-forward re-checks: widening it here would clear a row the next
+    // scan would only report again. The exact-title query is narrower than the index's fully normalized key,
+    // so like OwnsByName it can only fail toward leaving a gap listed, never toward hiding one.
+    private bool OwnsByName(BaseItemKind kind, string? artist, string? title)
+    {
+        if (kind != BaseItemKind.MusicAlbum || string.IsNullOrEmpty(title))
+        {
+            return false;
+        }
+
+        var wanted = OwnershipIndex.NameKey(artist, title);
+        foreach (var item in _libraryManager.GetItemList(new InternalItemsQuery
+        {
+            IncludeItemTypes = new[] { BaseItemKind.MusicAlbum },
+            IsVirtualItem = false,
+            Name = title,
+            Recursive = true
+        }))
+        {
+            if (item is MusicAlbum album
+                && string.Equals(OwnershipIndex.NameKey(album.AlbumArtist, album.Name), wanted, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Jellyfin.Plugin.MindTheGaps/Gaps/RecheckRunner.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Gaps/RecheckRunner.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.MindTheGaps.Gaps;
+
+/// <summary>
+/// Runs a bulk re-check in the background so a heading with many sets under it (every studio, every
+/// collection) does not block, and time out, the HTTP request that triggers it. Each owning item is swapped
+/// into the report as it finishes, so progress survives a cancelled run. Only one bulk re-check runs at a
+/// time; a second request while one is running is a no-op.
+/// </summary>
+public sealed class RecheckRunner
+{
+    private readonly GapEngine _engine;
+    private readonly PluginLifetime _lifetime;
+    private readonly ILogger<RecheckRunner> _logger;
+    private readonly object _lock = new();
+    // The run claim is a lock-free flag (0 = idle, 1 = running), claimed with a single atomic
+    // compare-and-set; the rest of the status stays under _lock so a read is one consistent snapshot.
+    private int _running;
+    private double _progress;
+    private int _total;
+    private int _done;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RecheckRunner"/> class.
+    /// </summary>
+    /// <param name="engine">The gap engine, which re-checks the batch.</param>
+    /// <param name="lifetime">The plugin-lifetime cancellation, so a run stops on shutdown.</param>
+    /// <param name="logger">The logger.</param>
+    public RecheckRunner(GapEngine engine, PluginLifetime lifetime, ILogger<RecheckRunner> logger)
+    {
+        _engine = engine;
+        _lifetime = lifetime;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether a bulk re-check is currently running.
+    /// </summary>
+    public bool IsRunning => Volatile.Read(ref _running) != 0;
+
+    /// <summary>
+    /// Gets the progress (0-100) of the running re-check.
+    /// </summary>
+    public double Progress
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _progress;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets how many owning items the running (or last) re-check was asked to cover.
+    /// </summary>
+    public int Total
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _total;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets how many owning items the running (or last) re-check has finished.
+    /// </summary>
+    public int Done
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _done;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Starts a bulk re-check of the given owning items in the background, if one is not already running.
+    /// </summary>
+    /// <param name="ownerIds">The owning library items to re-check.</param>
+    /// <returns><see langword="true"/> if this call started a run; <see langword="false"/> if one was already running or no ids were given.</returns>
+    public bool TryStart(IReadOnlyList<Guid> ownerIds)
+    {
+        if (ownerIds is null || ownerIds.Count == 0)
+        {
+            return false;
+        }
+
+        if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
+        {
+            return false;
+        }
+
+        // Snapshot the ids so a caller cannot mutate the list after we start.
+        var picked = ownerIds.ToList();
+
+        lock (_lock)
+        {
+            _progress = 0;
+            _total = picked.Count;
+            _done = 0;
+        }
+
+        // Detached from the request token on purpose: the run must outlive the request that started it. It
+        // observes the plugin-lifetime token so it stops on shutdown.
+        _ = Task.Run(() => RunAsync(picked));
+        return true;
+    }
+
+    private async Task RunAsync(IReadOnlyList<Guid> ownerIds)
+    {
+        try
+        {
+            _logger.LogInformation("Background re-check started for {Count} item(s)", ownerIds.Count);
+            var progress = new Progress<double>(p =>
+            {
+                lock (_lock)
+                {
+                    _progress = p;
+                    _done = (int)Math.Round(p / 100.0 * _total);
+                }
+            });
+
+            var done = await _engine.RecheckManyAsync(ownerIds, progress, _lifetime.Stopping).ConfigureAwait(false);
+            _logger.LogInformation("Background re-check finished: {Done} of {Asked} item(s)", done, ownerIds.Count);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning("Background re-check cancelled (plugin shutting down)");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Background re-check failed");
+        }
+        finally
+        {
+            lock (_lock)
+            {
+                _progress = 100;
+            }
+
+            Volatile.Write(ref _running, 0);
+        }
+    }
+}

--- a/Jellyfin.Plugin.MindTheGaps/Gaps/Sources/Books/BooksBibliographyGapSource.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Gaps/Sources/Books/BooksBibliographyGapSource.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.MindTheGaps.Configuration;
 using Jellyfin.Plugin.MindTheGaps.Model;
@@ -20,7 +22,7 @@ namespace Jellyfin.Plugin.MindTheGaps.Gaps.Sources.Books;
 /// person/tag), so this is a deliberately modest slice: it resolves the author by name, lists that
 /// author's works, and diffs them against owned books by OpenLibrary work key.
 /// </summary>
-internal sealed class BooksBibliographyGapSource : IGapSource
+internal sealed class BooksBibliographyGapSource : IGapSource, ISetContentSource
 {
     // OpenLibrary is keyless but still rate-limited; each author is two calls, so cap distinct authors.
     private const int MaxAuthors = 100;
@@ -52,7 +54,14 @@ internal sealed class BooksBibliographyGapSource : IGapSource
     public IReadOnlyCollection<BaseItemKind> OwnedKinds { get; } = new[] { BaseItemKind.Book };
 
     /// <inheritdoc />
+    public string GapIdPrefix => "bibliography:";
+
+    /// <inheritdoc />
     public bool IsEnabled(PluginConfiguration config) => config.ScanBooks;
+
+    /// <inheritdoc />
+    public bool Claims(BaseItem owner)
+        => owner is not null && owner.GetBaseItemKind() == BaseItemKind.Book;
 
     /// <inheritdoc />
     public async IAsyncEnumerable<GapItem> FindGapsAsync(
@@ -95,49 +104,72 @@ internal sealed class BooksBibliographyGapSource : IGapSource
 
             processed++;
 
-            string? authorKey;
-            IReadOnlyList<OpenLibraryWork> works;
-            try
+            var gaps = await CheckOneAsync(book, context, cancellationToken).ConfigureAwait(false);
+            if (gaps is null)
             {
-                // Prefer resolving the author from the owned book's own OpenLibrary work id: that reads the
-                // work's author directly and skips the name search (where a common name resolves the wrong
-                // namesake). Fall back to the name search only when the book carries no work id.
-                var ownedWorkId = OwnedWorkId(book);
-                authorKey = string.IsNullOrEmpty(ownedWorkId)
-                    ? null
-                    : await _openLibrary.GetWorkAuthorKeyAsync(ownedWorkId, cancellationToken).ConfigureAwait(false);
-                authorKey ??= await _openLibrary.ResolveAuthorKeyAsync(authorName, cancellationToken).ConfigureAwait(false);
-                if (string.IsNullOrEmpty(authorKey))
-                {
-                    continue;
-                }
-
-                works = await _openLibrary.GetAuthorWorksBySearchAsync(authorKey, cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                _logger.LogWarning(ex, "Bibliography: OpenLibrary lookup failed for author {Author}", authorName);
+                // Nothing determined for this author (unresolvable, or OpenLibrary failed). Skip to the
+                // next book rather than ending the source's whole pass.
                 continue;
             }
-
-            if (works.Count == 0)
-            {
-                continue;
-            }
-
-            var gaps = OpenLibraryMapper.Build(
-                authorKey,
-                authorName,
-                works,
-                book.Id.ToString("N", CultureInfo.InvariantCulture),
-                context.Ownership,
-                context.Config.MaxRelatedPerItem);
 
             foreach (var gap in gaps)
             {
                 yield return gap;
             }
         }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<GapItem>?> CheckOneAsync(BaseItem owner, GapScanContext context, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var authorName = ResolveAuthorName(owner);
+        if (string.IsNullOrEmpty(authorName))
+        {
+            // Nothing to resolve by, so nothing was determined about this author's bibliography.
+            return null;
+        }
+
+        string? authorKey;
+        IReadOnlyList<OpenLibraryWork> works;
+        try
+        {
+            // Prefer resolving the author from the owned book's own OpenLibrary work id: that reads the
+            // work's author directly and skips the name search (where a common name resolves the wrong
+            // namesake). Fall back to the name search only when the book carries no work id.
+            var ownedWorkId = OwnedWorkId(owner);
+            authorKey = string.IsNullOrEmpty(ownedWorkId)
+                ? null
+                : await _openLibrary.GetWorkAuthorKeyAsync(ownedWorkId, cancellationToken).ConfigureAwait(false);
+            authorKey ??= await _openLibrary.ResolveAuthorKeyAsync(authorName, cancellationToken).ConfigureAwait(false);
+            if (string.IsNullOrEmpty(authorKey))
+            {
+                return null;
+            }
+
+            works = await _openLibrary.GetAuthorWorksBySearchAsync(authorKey, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Bibliography: OpenLibrary lookup failed for author {Author}", authorName);
+            return null;
+        }
+
+        if (works.Count == 0)
+        {
+            // OpenLibrary answered and listed nothing, which is a real answer.
+            return [];
+        }
+
+        return OpenLibraryMapper.Build(
+            authorKey,
+            authorName,
+            works,
+            owner.Id.ToString("N", CultureInfo.InvariantCulture),
+            context.Ownership,
+            context.Config.MaxRelatedPerItem).ToList();
     }
 
     // The owned book's OpenLibrary work id, if its metadata carries one (the OpenLibrary metadata plugin

--- a/Jellyfin.Plugin.MindTheGaps/Gaps/Sources/Discogs/DiscogsArtistGapSource.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Gaps/Sources/Discogs/DiscogsArtistGapSource.cs
@@ -53,11 +53,14 @@ internal sealed class DiscogsArtistGapSource : MusicArtistGapSourceBase
     protected override string ServiceName => ServiceNames.Discogs;
 
     /// <inheritdoc />
+    public override string GapIdPrefix => "discogsartist:";
+
+    /// <inheritdoc />
     public override bool IsEnabled(PluginConfiguration config)
         => config.ScanDiscogs && !string.IsNullOrEmpty(config.DiscogsToken);
 
     /// <inheritdoc />
-    protected override async Task<(IReadOnlyList<GapItem> Gaps, bool CallSpent)> ProcessArtistAsync(
+    protected override async Task<(IReadOnlyList<GapItem>? Gaps, bool CallSpent)> ProcessArtistAsync(
         BaseItem artist,
         GapScanContext context,
         CancellationToken cancellationToken)
@@ -66,12 +69,12 @@ internal sealed class DiscogsArtistGapSource : MusicArtistGapSourceBase
         // artists they cannot scan, so the two never report the same album twice.
         if (artist.TryGetProviderId(ProviderIds.MusicBrainzArtist, out var mbid) && !string.IsNullOrEmpty(mbid))
         {
-            return ([], false);
+            return (null, false);
         }
 
         if (string.IsNullOrEmpty(artist.Name))
         {
-            return ([], false);
+            return (null, false);
         }
 
         // Only scan an artist the library has already identified on Discogs. The id resolves from the item with
@@ -79,7 +82,7 @@ internal sealed class DiscogsArtistGapSource : MusicArtistGapSourceBase
         var artistId = DiscogsArtistDiscography.ResolveId(artist);
         if (artistId is null)
         {
-            return ([], false);
+            return (null, false);
         }
 
         IReadOnlyList<DiscogsRelease> releases;
@@ -90,7 +93,7 @@ internal sealed class DiscogsArtistGapSource : MusicArtistGapSourceBase
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             Logger.LogWarning(ex, "Discogs artists: failed to fetch releases for {Name} (Discogs {ArtistId})", artist.Name, artistId.Value);
-            return ([], true);
+            return (null, true);
         }
 
         var pattern = OwnsAlbumByArtist(artist) ? GapPattern.SetCompletion : GapPattern.CreatorWorks;

--- a/Jellyfin.Plugin.MindTheGaps/Gaps/Sources/Music/MusicArtistGapSourceBase.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Gaps/Sources/Music/MusicArtistGapSourceBase.cs
@@ -20,7 +20,7 @@ namespace Jellyfin.Plugin.MindTheGaps.Gaps.Sources.Music;
 /// resolve, fetch, and map each artist's discography. The provider-specific parts (which service, and how to
 /// process one artist) are abstract, so the providers share this loop rather than each re-implementing it.
 /// </summary>
-internal abstract class MusicArtistGapSourceBase : IGapSource
+internal abstract class MusicArtistGapSourceBase : IGapSource, ISetContentSource
 {
     // Each artist costs at least one paced request, so cap the artists scanned per run the way the people
     // source caps people. The cap counts artists for which an API call is spent, not artists skipped early.
@@ -42,6 +42,9 @@ internal abstract class MusicArtistGapSourceBase : IGapSource
 
     /// <inheritdoc />
     public IReadOnlyCollection<BaseItemKind> OwnedKinds { get; } = new[] { BaseItemKind.MusicAlbum };
+
+    /// <inheritdoc />
+    public abstract string GapIdPrefix { get; }
 
     /// <summary>
     /// Gets the library manager, so a subclass can classify an artist against the owned library.
@@ -102,11 +105,31 @@ internal abstract class MusicArtistGapSourceBase : IGapSource
                 processed++;
             }
 
+            if (gaps is null)
+            {
+                // Nothing determined for this artist (not this source's to handle, no usable id, or the
+                // provider failed). Move on to the next artist.
+                continue;
+            }
+
             foreach (var gap in gaps)
             {
                 yield return gap;
             }
         }
+    }
+
+    /// <inheritdoc />
+    public bool Claims(BaseItem owner)
+        => owner is not null && owner.GetBaseItemKind() == BaseItemKind.MusicArtist;
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<GapItem>?> CheckOneAsync(BaseItem owner, GapScanContext context, CancellationToken cancellationToken)
+    {
+        // The per-artist step the scan loop already calls; a re-check is that same step on its own, so the
+        // per-run artist cap and the circuit check (both properties of a whole run) do not apply.
+        var (gaps, _) = await ProcessArtistAsync(owner, context, cancellationToken).ConfigureAwait(false);
+        return gaps;
     }
 
     /// <summary>
@@ -118,8 +141,13 @@ internal abstract class MusicArtistGapSourceBase : IGapSource
     /// <param name="artist">The owned library artist.</param>
     /// <param name="context">The scan context.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The gaps for this artist, and whether an API call was spent.</returns>
-    protected abstract Task<(IReadOnlyList<GapItem> Gaps, bool CallSpent)> ProcessArtistAsync(
+    /// <returns>
+    /// The gaps for this artist, empty when the provider answered and the artist is missing nothing, or
+    /// <see langword="null"/> when nothing was determined (the provider failed, or the artist carries no id
+    /// this source can resolve). A re-check replaces an artist's gaps, so the two must not be conflated.
+    /// Also returns whether an API call was spent, so the per-run cap bounds calls rather than artists.
+    /// </returns>
+    protected abstract Task<(IReadOnlyList<GapItem>? Gaps, bool CallSpent)> ProcessArtistAsync(
         BaseItem artist,
         GapScanContext context,
         CancellationToken cancellationToken);

--- a/Jellyfin.Plugin.MindTheGaps/Gaps/Sources/Music/MusicBrainzArtistGapSourceBase.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Gaps/Sources/Music/MusicBrainzArtistGapSourceBase.cs
@@ -55,6 +55,9 @@ internal abstract class MusicBrainzArtistGapSourceBase : MusicArtistGapSourceBas
     /// <inheritdoc />
     protected override string ServiceName => ServiceNames.MusicBrainz;
 
+    /// <inheritdoc />
+    public override string GapIdPrefix => IdPrefix + ":";
+
     /// <summary>
     /// Gets the pattern this source tags its gaps with.
     /// </summary>
@@ -74,7 +77,7 @@ internal abstract class MusicBrainzArtistGapSourceBase : MusicArtistGapSourceBas
     protected abstract bool Handles(BaseItem artist);
 
     /// <inheritdoc />
-    protected override async Task<(IReadOnlyList<GapItem> Gaps, bool CallSpent)> ProcessArtistAsync(
+    protected override async Task<(IReadOnlyList<GapItem>? Gaps, bool CallSpent)> ProcessArtistAsync(
         BaseItem artist,
         GapScanContext context,
         CancellationToken cancellationToken)
@@ -84,13 +87,13 @@ internal abstract class MusicBrainzArtistGapSourceBase : MusicArtistGapSourceBas
         if (!artist.TryGetProviderId(ProviderIds.MusicBrainzArtist, out var artistMbid)
             || !Guid.TryParse(artistMbid, out _))
         {
-            return ([], false);
+            return (null, false);
         }
 
         // Classify against the library (a cheap indexed lookup) before spending a MusicBrainz call.
         if (!Handles(artist))
         {
-            return ([], false);
+            return (null, false);
         }
 
         IReadOnlyList<MusicBrainzReleaseGroup> albums;
@@ -101,7 +104,7 @@ internal abstract class MusicBrainzArtistGapSourceBase : MusicArtistGapSourceBas
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             Logger.LogWarning(ex, "{Source}: failed to fetch MusicBrainz albums for {Name} ({Mbid})", Name, artist.Name, artistMbid);
-            return ([], true);
+            return (null, true);
         }
 
         var gaps = MusicBrainzMapper.Build(

--- a/Jellyfin.Plugin.MindTheGaps/Gaps/Sources/Tmdb/CollectionGapSource.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Gaps/Sources/Tmdb/CollectionGapSource.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.MindTheGaps.Configuration;
 using Jellyfin.Plugin.MindTheGaps.Model;
@@ -26,7 +28,7 @@ namespace Jellyfin.Plugin.MindTheGaps.Gaps.Sources.Tmdb;
 /// container). Series in a mixed collection are left alone. Missing shows within a franchise is handled
 /// by the TVDB/TVMaze/Trakt sources (e.g. Wikidata P179 "part of the series" or Trakt lists).
 /// </remarks>
-internal sealed class CollectionGapSource : IGapSource
+internal sealed class CollectionGapSource : IGapSource, ISetContentSource
 {
     private readonly ILibraryManager _libraryManager;
     private readonly TmdbClient _tmdb;
@@ -55,16 +57,20 @@ internal sealed class CollectionGapSource : IGapSource
     public IReadOnlyCollection<BaseItemKind> OwnedKinds { get; } = new[] { BaseItemKind.Movie };
 
     /// <inheritdoc />
+    public string GapIdPrefix => "collection:";
+
+    /// <inheritdoc />
     public bool IsEnabled(PluginConfiguration config) => config.ScanCollections;
+
+    /// <inheritdoc />
+    public bool Claims(BaseItem owner)
+        => owner is not null && owner.GetBaseItemKind() == BaseItemKind.BoxSet;
 
     /// <inheritdoc />
     public async IAsyncEnumerable<GapItem> FindGapsAsync(
         GapScanContext context,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var language = context.Config.MetadataLanguage;
-        var country = context.Config.MetadataCountryCode;
-
         var boxSets = _libraryManager.GetItemList(new InternalItemsQuery
         {
             IncludeItemTypes = new[] { BaseItemKind.BoxSet },
@@ -77,41 +83,60 @@ internal sealed class CollectionGapSource : IGapSource
             cancellationToken.ThrowIfCancellationRequested();
             context.ReportProgress((double)index++ / Math.Max(1, boxSets.Count));
 
-            if (!boxSet.TryGetProviderId(ProviderIds.Tmdb, out var idStr)
-                || !int.TryParse(idStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out var collectionId))
+            var gaps = await CheckOneAsync(boxSet, context, cancellationToken).ConfigureAwait(false);
+            if (gaps is null)
             {
+                // Nothing determined for this collection (no TMDB id, or the fetch failed). Skip it and
+                // keep scanning: the scan's carry-forward keeps whatever it already had.
                 continue;
             }
-
-            Collection? collection = null;
-            try
-            {
-                collection = await _tmdb
-                    .GetCollectionAsync(collectionId, language, country, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to fetch TMDB collection {CollectionId} for {Name}", collectionId, boxSet.Name);
-            }
-
-            if (collection?.Parts is null)
-            {
-                continue;
-            }
-
-            var gaps = CollectionGapMapper.Build(
-                collectionId,
-                collection.Parts,
-                boxSet.Id.ToString("N", CultureInfo.InvariantCulture),
-                boxSet.Name,
-                context.Ownership,
-                _tmdb.GetPosterUrl);
 
             foreach (var gap in gaps)
             {
                 yield return gap;
             }
         }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<GapItem>?> CheckOneAsync(BaseItem owner, GapScanContext context, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (!owner.TryGetProviderId(ProviderIds.Tmdb, out var idStr)
+            || !int.TryParse(idStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out var collectionId))
+        {
+            // No TMDB id to diff against: undetermined, not "complete".
+            return null;
+        }
+
+        Collection? collection;
+        try
+        {
+            collection = await _tmdb
+                .GetCollectionAsync(collectionId, context.Config.MetadataLanguage, context.Config.MetadataCountryCode, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Cancellation is deliberately not caught: a shutdown mid-batch must abort the run, not report
+            // this collection as merely unresolvable and let the batch carry on.
+            _logger.LogWarning(ex, "Failed to fetch TMDB collection {CollectionId} for {Name}", collectionId, owner.Name);
+            return null;
+        }
+
+        if (collection?.Parts is null)
+        {
+            return null;
+        }
+
+        return CollectionGapMapper.Build(
+            collectionId,
+            collection.Parts,
+            owner.Id.ToString("N", CultureInfo.InvariantCulture),
+            owner.Name,
+            context.Ownership,
+            _tmdb.GetPosterUrl).ToList();
     }
 }

--- a/Jellyfin.Plugin.MindTheGaps/Gaps/TodoStore.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Gaps/TodoStore.cs
@@ -174,6 +174,43 @@ public sealed class TodoStore
         }
     }
 
+    /// <summary>
+    /// Applies a done state to many entries at once, under one lock and with a single flush. The per-entry
+    /// <see cref="SetDone"/> serializes the whole file each call, so a bulk verify that touched N entries
+    /// would otherwise write the file N times.
+    /// </summary>
+    /// <param name="states">The wanted done state per entry id. Ids the list does not hold are ignored.</param>
+    /// <returns>The number of entries whose state actually changed.</returns>
+    public int ReconcileDone(IReadOnlyDictionary<string, bool> states)
+    {
+        ArgumentNullException.ThrowIfNull(states);
+
+        lock (_lock)
+        {
+            var map = LoadMap();
+            var changed = 0;
+            foreach (var pair in states)
+            {
+                if (!map.TryGetValue(pair.Key, out var entry) || entry.Done == pair.Value)
+                {
+                    continue;
+                }
+
+                entry.Done = pair.Value;
+                entry.DoneUtc = pair.Value ? NowUtc() : null;
+                changed++;
+            }
+
+            // Only write when something moved, so a verify that confirms the status quo costs no disk at all.
+            if (changed > 0)
+            {
+                Flush(map);
+            }
+
+            return changed;
+        }
+    }
+
     // A round-trippable UTC instant for the added/done timestamps.
     private static string NowUtc()
         => DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture);

--- a/Jellyfin.Plugin.MindTheGaps/Model/RecheckStatus.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Model/RecheckStatus.cs
@@ -1,0 +1,33 @@
+namespace Jellyfin.Plugin.MindTheGaps.Model;
+
+/// <summary>
+/// The state of the background bulk re-check, so the dashboard can show its progress and reload the report
+/// when it finishes.
+/// </summary>
+public class RecheckStatus
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether a bulk re-check is currently running.
+    /// </summary>
+    public bool Running { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this request started a run (false if one was already running).
+    /// </summary>
+    public bool Started { get; set; }
+
+    /// <summary>
+    /// Gets or sets the running re-check's progress, from 0 to 100.
+    /// </summary>
+    public double Progress { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many owning items the run was asked to cover.
+    /// </summary>
+    public int Total { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many owning items the run has finished.
+    /// </summary>
+    public int Done { get; set; }
+}

--- a/Jellyfin.Plugin.MindTheGaps/Model/TodoVerifyAllResult.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Model/TodoVerifyAllResult.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.MindTheGaps.Model;
+
+/// <summary>
+/// The outcome of verifying the whole todo list against the library: how much was checked, how much the
+/// library now holds, and the list with every entry's done state brought up to date.
+/// </summary>
+public class TodoVerifyAllResult
+{
+    /// <summary>
+    /// Gets or sets how many entries were checked.
+    /// </summary>
+    public int Checked { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many of them the library now holds, and which are therefore marked done.
+    /// </summary>
+    public int Owned { get; set; }
+
+    /// <summary>
+    /// Gets or sets the todo list after the pass, so the dashboard can re-render without a second fetch.
+    /// </summary>
+    public IReadOnlyList<TodoEntry> Items { get; set; } = [];
+}

--- a/Jellyfin.Plugin.MindTheGaps/Model/VerifyResult.cs
+++ b/Jellyfin.Plugin.MindTheGaps/Model/VerifyResult.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.MindTheGaps.Model;
+
+/// <summary>
+/// The outcome of a verify pass: how many of the submitted gaps were checked against the library, and which
+/// of them the library now holds (and were therefore dropped from the report).
+/// </summary>
+public class VerifyResult
+{
+    /// <summary>
+    /// Gets or sets how many of the submitted ids matched a gap still in the report and were checked. Ids the
+    /// report no longer holds are skipped rather than counted.
+    /// </summary>
+    public int Checked { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many of the checked gaps the library now holds.
+    /// </summary>
+    public int Owned { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many gaps were removed in total. This is at least <see cref="Owned"/> and usually
+    /// more: one acquired title is a gap in every set that wanted it, so confirming it drops all of them,
+    /// including rows on tabs the client has not loaded.
+    /// </summary>
+    public int Removed { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ids of every gap removed, so the dashboard can drop exactly those rows without
+    /// reloading the whole report.
+    /// </summary>
+    public IReadOnlyList<string> RemovedIds { get; set; } = [];
+}

--- a/Jellyfin.Plugin.MindTheGaps/ServiceRegistrator.cs
+++ b/Jellyfin.Plugin.MindTheGaps/ServiceRegistrator.cs
@@ -40,10 +40,12 @@ public sealed class ServiceRegistrator : IPluginServiceRegistrator
         serviceCollection.AddSingleton<TodoStore>();
         serviceCollection.AddSingleton<ScanCursorStore>();
         serviceCollection.AddSingleton<ExternalLinkEnricher>();
+        serviceCollection.AddSingleton<LibraryVerifier>();
         serviceCollection.AddSingleton<ExploreRegistry>();
         serviceCollection.AddSingleton<GapEngine>();
         serviceCollection.AddSingleton<GapScanRunner>();
         serviceCollection.AddSingleton<ExploreRunner>();
+        serviceCollection.AddSingleton<RecheckRunner>();
         serviceCollection.AddSingleton<TmdbClient>();
         serviceCollection.AddSingleton<WebhookNotifier>();
         serviceCollection.AddSingleton<CachedApiClient>();

--- a/Jellyfin.Plugin.MindTheGaps/Web/mindthegaps.report.body.html
+++ b/Jellyfin.Plugin.MindTheGaps/Web/mindthegaps.report.body.html
@@ -51,6 +51,9 @@
             <button is="emby-button" type="button" id="cgTodoBtn" class="raised" style="margin:0;" title="Open your personal TODO list of gaps to go find. Add items with the per-row TODO button or the multi-select bar.">
                 <span>My TODO list</span>
             </button>
+            <button is="emby-button" type="button" id="cgVerifyShown" class="raised" style="margin:0;" title="Check every row currently shown against your library and clear the ones you now have, then offer a provider re-check for whatever is still missing.">
+                <span>Clear what I have</span>
+            </button>
             <input type="text" is="emby-input" id="cgSearch" placeholder="search title&hellip;" aria-label="Search titles and sources" style="flex:1 1 14em;min-width:12em;max-width:30em;margin:0;" />
         </div>
         <div style="font-size:.9em;opacity:.85;margin-bottom:.4em;">

--- a/Jellyfin.Plugin.MindTheGaps/Web/mindthegaps.report.html
+++ b/Jellyfin.Plugin.MindTheGaps/Web/mindthegaps.report.html
@@ -88,10 +88,11 @@
                                 <span class="material-icons" aria-hidden="true">close</span>
                             </button>
                         </div>
-                        <p class="fieldDescription" style="margin:0 0 .8em 0;">Gaps you have flagged to go find. Tick a row when you have it, Verify checks your library for it, and Delete removes it. The list survives rescans.</p>
+                        <p class="fieldDescription" style="margin:0 0 .8em 0;">Gaps you have flagged to go find. Tick a row when you have it, Verify checks your library for that one, Verify all checks the lot, and Delete removes it. The list survives rescans.</p>
                         <div id="cgTodoBody"></div>
                         <div style="display:flex;align-items:center;gap:.6em;flex-wrap:wrap;margin-top:.9em;">
-                            <button is="emby-button" type="button" id="cgTodoExport" class="raised"><span>Export Markdown</span></button>
+                            <button is="emby-button" type="button" id="cgTodoVerifyAll" class="raised" title="Check every entry against your library now and tick the ones you have."><span>Verify all</span></button>
+                            <button is="emby-button" type="button" id="cgTodoExport" class="raised" title="Check every entry against your library, then download the list as a Markdown checklist."><span>Export Markdown</span></button>
                         </div>
                     </div>
                 </div>

--- a/Jellyfin.Plugin.MindTheGaps/Web/mindthegaps.report.js
+++ b/Jellyfin.Plugin.MindTheGaps/Web/mindthegaps.report.js
@@ -189,12 +189,35 @@ function batchDismissBtns(label) {
         + ' ' + cgAnchor('cgBatchNotInterested', { 'data-label': label, title: 'Mark all listed items here as not interested', 'aria-label': 'Mark all listed items here as not interested' }, icon('close'));
 }
 
-// The refresh control on a series or season header: re-checks just that series now (the server
-// swaps its gaps), so a metadata fix can be verified without a full rescan. Carries the series
-// id; a season's control re-checks its whole series.
-function recheckBtn(seriesId) {
-    if (!seriesId) { return ''; }
-    return ' ' + cgAnchor('cgRecheck', { 'data-series': seriesId, title: 'Re-check this series now', 'aria-label': 'Re-check this series now' }, icon('refresh'));
+// Whether the server can re-run the source behind this owning item on its own, which is what the
+// clear-down offers once a verify leaves something still missing. Every Set completion owner that is
+// a library item qualifies (a BoxSet, a Series, a MusicArtist, a Book), as does a music or book
+// creator. A studio, keyword, label, or curated list carries a synthetic owner id, not a library
+// one; a film filmography and a recommendation seed have no per-item re-check at all. Offering one
+// for those would prompt for a pass the server would then skip.
+function ownerRecheckable(it) {
+    if (!it || !isGuidId(it.SourceItemId)) { return false; }
+    if (it.PatternName === 'SetCompletion') { return true; }
+    return it.PatternName === 'CreatorWorks' && (it.DomainName === 'Music' || it.DomainName === 'Books');
+}
+
+// An N-format Jellyfin guid, which is what a library-backed source carries in SourceItemId. The
+// rest (a curated list, a studio, a Discogs label) carries a synthetic key like "mdblist-123",
+// which no per-item re-check can resolve back to a library item.
+function isGuidId(id) { return /^[0-9a-f]{32}$/i.test(id || ''); }
+
+// The one clear-down control, on every level of the tree and on every row. Stage one always checks
+// the rows in scope against the library and drops the ones you now hold; if any survive and their
+// sources can be re-run, stage two offers to ask the providers again. scope/season narrow what the
+// click covers: a domain, a set kind, one group, one season, or a single row.
+function clearBtn(scope, key, label) {
+    var title = 'Check ' + label + ' against your library and clear what you now have, then offer a provider re-check for the rest';
+    return ' ' + cgAnchor('cgClear', {
+        'data-scope': scope,
+        'data-key': key == null ? '' : String(key),
+        title: title,
+        'aria-label': title
+    }, icon('refresh'));
 }
 
 // The greyed status line for a dismissed gap.
@@ -431,7 +454,8 @@ function renderRow(item) {
         : h('span', { style: 'display:inline-block;width:1.4em;flex:none;' }).outerHTML;
 
     var titleLine = wrap('div', { 'class': 'listItemBodyText cgRowTitle' },
-        esc(item.Name) + searchIcon(item.Name, domainScope(item.DomainName)) + openIcon(item.LibraryItemId));
+        esc(item.Name) + searchIcon(item.Name, domainScope(item.DomainName)) + openIcon(item.LibraryItemId)
+            + clearBtn('row', item.Id, 'this title'));
     var secondaryLine = wrap('div', { 'class': 'listItemBodyText secondary' }, meta.join(' &middot; '));
     var body = wrap('div', { style: 'flex:1;min-width:0;' },
         titleLine + secondaryLine + details + avail + resolvedLine + linksRow);
@@ -864,7 +888,9 @@ function sourceBody(items) {
         var seasonDiag = (key !== 'na' && n > 0)
             ? seasonDiagnoseBtn(seasonItems[0].Id, (seriesName ? seriesName + ' ' : '') + label)
             : '';
-        var seasonExtra = searchIcon(seriesName, 'tvshows') + openIcon(openId) + recheckBtn(seasonItems[0].SourceItemId) + seasonDiag + batchDismissBtns(label);
+        var seasonExtra = searchIcon(seriesName, 'tvshows') + openIcon(openId)
+            + clearBtn('season', (seriesName || '') + '|' + key, 'this season')
+            + seasonDiag + batchDismissBtns(label);
         return groupHtml(3, label, seasonItems.length, true, sortRows(seasonItems).map(renderRow).join(''), '', seasonExtra);
     }).join('');
 }
@@ -999,7 +1025,7 @@ function setSourceCell(src, srcItems) {
         + coverageBadge(covItem)
         + searchIcon(src, searchScope)
         + openIcon(srcItems[0].SourceItemId)
-        + (isEpisodic ? recheckBtn(srcItems[0].SourceItemId) : '')
+        + clearBtn('group', src, 'everything listed under ' + src)
         + (isEpisodic ? batchDismissBtns(src) : '')
         + sourceLinks(srcItems[0]);
     // For a series, put the show's year in the header so same-named reboots are distinguishable
@@ -1027,7 +1053,7 @@ function buildTree(items) {
             var sItems = bySource.map[src];
             var token = 'lz' + (++cgGroupSeq);
             lazyBodies[token] = function () { return sortRows(sItems).map(renderRow).join(''); };
-            return groupHtml(2, src, sItems.length, true, '', sItems[0].SourceItemId, streamDot(sItems) + searchIcon(src, '') + recSourceDismissBtn(sItems[0].SourceItemId, src) + sourceLinks(sItems[0]), token);
+            return groupHtml(2, src, sItems.length, true, '', sItems[0].SourceItemId, streamDot(sItems) + searchIcon(src, '') + clearBtn('group', src, 'everything listed under ' + src) + recSourceDismissBtn(sItems[0].SourceItemId, src) + sourceLinks(sItems[0]), token);
         }).join('');
     }
 
@@ -1040,7 +1066,7 @@ function buildTree(items) {
             // tab with tens of thousands of rows renders just the headers up front.
             var token = 'lz' + (++cgGroupSeq);
             lazyBodies[token] = function () { return sortRows(cItems).map(renderRow).join(''); };
-            return groupHtml(2, src, cItems.length, true, '', cItems[0].SourceItemId, streamDot(cItems) + searchIcon(src, '') + creatorDismissBtn(cItems[0].SourceItemId, src) + sourceLinks(cItems[0]), token);
+            return groupHtml(2, src, cItems.length, true, '', cItems[0].SourceItemId, streamDot(cItems) + searchIcon(src, '') + clearBtn('group', src, 'everything listed under ' + src) + creatorDismissBtn(cItems[0].SourceItemId, src) + sourceLinks(cItems[0]), token);
         }).join('');
     }
 
@@ -1062,7 +1088,8 @@ function buildTree(items) {
         // group machinery so its caret, keyboard toggle, and persisted state all come for free.
         if (!multiKind) { return grid; }
         var hdr = wrap('div', { 'class': 'cgHdr cgKindHdr', role: 'button', tabindex: '0', 'aria-expanded': 'true' },
-            h('span', { 'class': 'cgCaret' }).outerHTML + h('span', { 'class': 'cgLabel' }, kind).outerHTML);
+            h('span', { 'class': 'cgCaret' }).outerHTML + h('span', { 'class': 'cgLabel' }, kind).outerHTML
+                + clearBtn('kind', kind, 'everything under ' + kind));
         return wrap('div', { 'class': 'cgGroup cgKindGroup', 'data-cglabel': 'kind:' + kind },
             hdr + wrap('div', { 'class': 'cgBody' }, grid));
     }).join('');
@@ -1238,10 +1265,17 @@ function gapDetail(it) {
 // domain folded into the title "Mind the Gaps: Movies Set completion"), an H2 per source group
 // (the set's kind, the creator, or the recommending title), and each gap as an H3 with a detail
 // line. A table of contents jumps to each group. The summary line links to a shareable view.
-function buildMarkdown(page) {
+// Everything the export writes: the current tab under the current filters, across every letter. Note
+// this is deliberately wider than page._shown, which the A-Z bar narrows to one letter on a big tab.
+// The verify that runs before an export uses this too, so it cannot check less than it writes.
+function exportItems(page) {
     var report = page._report || { Items: [] };
     var pass = buildFilter(page);
-    var items = (report.Items || []).filter(function (it) { return it.PatternName === page._pattern && pass(it); });
+    return (report.Items || []).filter(function (it) { return it.PatternName === page._pattern && pass(it); });
+}
+
+function buildMarkdown(page) {
+    var items = exportItems(page);
     // Angle brackets around the URL so encoded filter values cannot break the markdown link.
     var out = ['_[' + items.length + ' gaps, exported ' + new Date().toLocaleString() + '](<' + shareUrl(page) + '>)_', ''];
 
@@ -1523,7 +1557,8 @@ function rollupHtml(items) {
         });
         var nGroups = Object.keys(groups).length;
         var cov = totalSum ? ' ' + h('span', { 'class': 'cgRollupCov' }, '(' + ownedSum + ' of ' + totalSum + ' owned, ' + Math.round(ownedSum / totalSum * 100) + '%)').outerHTML : '';
-        return h('b', null, cat).outerHTML + ': ' + catItems.length + ' gaps across ' + nGroups + ' ' + noun + (nGroups === 1 ? '' : 's') + cov;
+        var clear = clearBtn('domain', cat, 'everything shown for ' + cat);
+        return h('b', null, cat).outerHTML + ': ' + catItems.length + ' gaps across ' + nGroups + ' ' + noun + (nGroups === 1 ? '' : 's') + cov + clear;
     });
     return parts.join(' &nbsp;&middot;&nbsp; ');
 }
@@ -1569,6 +1604,171 @@ function refreshAcqConfig(page) {
         }, function () { acqConfig = null; });
 }
 
+// The rows one clear-down click covers, taken from what the last render actually showed rather than
+// from the DOM: a collapsed Creator works or Discover group has no rows rendered yet, so reading the
+// DOM would silently verify nothing.
+function rowsInScope(page, scope, key) {
+    var shown = page._shown || [];
+    if (scope === 'row') { return shown.filter(function (it) { return it.Id === key; }); }
+    if (scope === 'domain') { return shown.filter(function (it) { return categoryOf(it) === key; }); }
+    if (scope === 'kind') { return shown.filter(function (it) { return setKindLabel(it.SourceItemType) === key; }); }
+    // Groups are rendered by SourceItemName, so the scope keys on that too. Keying on one member's
+    // SourceItemId would cover only one of two same-named creators or collections whose rows share a
+    // heading, silently leaving the other's rows behind.
+    if (scope === 'group') { return shown.filter(function (it) { return groupKeyOf(it) === key; }); }
+    if (scope === 'season') {
+        // "<group name>|<season groupBy key>", where an episode with no season files under 'na',
+        // matching how sourceBody groups them. Split on the last separator, since a name may contain one.
+        var cut = key.lastIndexOf('|');
+        var owner = key.slice(0, cut);
+        var season = key.slice(cut + 1);
+        return shown.filter(function (it) {
+            return groupKeyOf(it) === owner && (it.Season == null ? 'na' : String(it.Season)) === season;
+        });
+    }
+
+    return [];
+}
+
+// The heading a row is rendered under, matching what buildTree and setSourceCell group by.
+function groupKeyOf(it) { return it.SourceItemName || '(no source)'; }
+
+// How a clear-down names its scope in the messages it shows.
+function scopeLabel(scope, key, items) {
+    if (scope === 'row') { return ' (' + ((items[0] && items[0].Name) || 'this title') + ')'; }
+    if (scope === 'domain' || scope === 'kind') { return ' under ' + key; }
+    if (scope === 'season') { return ' in this season'; }
+    return ' in this group';
+}
+
+// Ask the server which of these gaps the library now holds; it drops those from the report and
+// returns their ids, which are pruned from every cached tab so a tab switch does not resurrect them.
+function verifyGaps(page, ids) {
+    return ApiClient.ajax({
+        type: 'POST',
+        url: ApiClient.getUrl('MindTheGaps/Verify'),
+        contentType: 'application/json',
+        data: JSON.stringify(ids)
+    }).then(function (res) {
+        var removed = {};
+        ((res && res.RemovedIds) || []).forEach(function (id) { removed[id] = true; });
+        if (!Object.keys(removed).length) { return res; }
+
+        pruneSlices(page, removed);
+
+        // Pruning can only adjust the counts for gaps we hold locally, and the whole point of the sweep is
+        // that it also clears rows on tabs never loaded. Re-read the summary so the totals and tab badges
+        // are the server's rather than a local approximation; failing that, keep the pruned estimate.
+        return ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl('MindTheGaps/Summary'), dataType: 'json' })
+            .then(function (summary) {
+                if (summary) { page._summary = summary; }
+                return res;
+            }, function () { return res; });
+    });
+}
+
+// Drop removed gaps from the loaded tab and every cached slice, so the list reflects the change without
+// re-fetching the report. The counts are not adjusted here: verifyGaps re-reads the summary, which is the
+// only thing that knows about rows removed from tabs this browser never loaded. The loaded tab is the
+// same object as its cached slice, so pruned reports are tracked to avoid filtering one twice.
+function pruneSlices(page, removed) {
+    var seen = [];
+    var prune = function (report) {
+        if (!report || !report.Items || seen.indexOf(report) !== -1) { return; }
+        seen.push(report);
+        report.Items = report.Items.filter(function (it) { return !removed[it.Id]; });
+    };
+
+    prune(page._report);
+    Object.keys(page._slices || {}).forEach(function (p) { prune(page._slices[p]); });
+}
+
+// The distinct owning items behind a set of rows that the server can actually re-run, in the order
+// they appear. A row whose owner has no per-item re-check contributes nothing, so the clear-down
+// never prompts for a pass the server would skip.
+function recheckableOwners(items) {
+    var seen = {};
+    var owners = [];
+    items.forEach(function (it) {
+        var src = it.SourceItemId || '';
+        if (!ownerRecheckable(it) || seen[src]) { return; }
+        seen[src] = true;
+        owners.push(src);
+    });
+    return owners;
+}
+
+// The clear-down every scope runs, from a single row up to a whole tab: verify the rows in scope,
+// drop what the library now holds, then offer to re-check the sources behind whatever survived. One
+// routine, so every level behaves identically at a different width.
+function clearDownScope(page, items, label) {
+    if (!items.length) { Dashboard.alert('Nothing shown to check.'); return Promise.resolve(); }
+    return verifyGaps(page, items.map(function (it) { return it.Id; })).then(function (res) {
+        var cleared = (res && res.Owned) || 0;
+        var left = items.length - cleared;
+        // The server drops every gap about a title it confirms you own, so acquiring one film can clear
+        // rows on tabs that are not even loaded (its collection, a studio set, a filmography). Say so,
+        // rather than have the totals move by more than the rows that visibly went.
+        var elsewhere = Math.max(0, ((res && res.Removed) || cleared) - cleared);
+        var also = elsewhere ? ' (and ' + elsewhere + ' more elsewhere in the report)' : '';
+        if (cleared) { applyAndRender(page); }
+        if (!left) {
+            Dashboard.alert('Cleared all ' + cleared + ' item(s)' + label + also + '; you have them all now.');
+            return;
+        }
+        // Re-check only the sources that still have something missing, not every source in scope, so a
+        // mostly-clear heading costs a handful of provider calls instead of one per set.
+        var removed = (res && res.RemovedIds) || [];
+        var owners = recheckableOwners(items.filter(function (it) { return removed.indexOf(it.Id) === -1; }));
+        var msg = cleared
+            ? 'Cleared ' + cleared + ' item(s)' + label + also + '. ' + left + ' still missing.'
+            : left + ' item(s)' + label + ' still missing.';
+        if (!owners.length) { Dashboard.alert(msg); return; }
+        if (!window.confirm(msg + '\n\nRe-check the ' + owners.length + ' source(s) they belong to with their providers? That runs in the background and also picks up anything added since the last scan.')) { return; }
+        return startBulkRecheck(page, owners);
+    });
+}
+
+// Stage two of a kind-level clear-down: hand the whole batch to the background runner and poll it,
+// since a heading can cover hundreds of sets and each one is a live provider call. The server builds
+// the ownership index once for the batch and swaps each set in as it finishes, so a run that is
+// interrupted still leaves the sets it got through up to date.
+function startBulkRecheck(page, ownerIds) {
+    return ApiClient.ajax({
+        type: 'POST',
+        url: ApiClient.getUrl('MindTheGaps/RecheckSources'),
+        contentType: 'application/json',
+        data: JSON.stringify(ownerIds)
+    }).then(function (st) {
+        if (st && !st.Started && st.Running) {
+            Dashboard.alert('A re-check is already running; wait for it to finish and try again.');
+            return;
+        }
+        Dashboard.showLoadingMsg();
+        return pollBulkRecheck(page);
+    }).catch(function () {
+        Dashboard.alert('Could not start the re-check. Check the server logs.');
+    });
+}
+
+function pollBulkRecheck(page) {
+    return ApiClient.getJSON(ApiClient.getUrl('MindTheGaps/RecheckStatus')).then(function (st) {
+        if (st && st.Running) {
+            return new Promise(function (resolve) { setTimeout(resolve, 1000); }).then(function () { return pollBulkRecheck(page); });
+        }
+        // Finished: the report changed underneath us, so drop the cached tabs and re-fetch this one.
+        if (page._slices) { page._slices[page._pattern] = null; }
+        return ensureSlice(page, page._pattern).then(function () {
+            Dashboard.hideLoadingMsg();
+            applyAndRender(page);
+            Dashboard.alert('Re-check finished' + (st && st.Total ? ' (' + st.Done + ' of ' + st.Total + ' set(s))' : '') + '.');
+        });
+    }).catch(function () {
+        Dashboard.hideLoadingMsg();
+        Dashboard.alert('Lost contact with the re-check. Check the server logs.');
+    });
+}
+
 function applyAndRender(page) {
     var report = page._report || { Items: [] };
     currentSort = page.querySelector('#cgSort').value || 'title';
@@ -1589,6 +1789,10 @@ function applyAndRender(page) {
     page._letter = letter;
     var displayItems = letter === '*' ? items
         : items.filter(function (it) { return itemLetters(it, page._pattern).indexOf(letter) !== -1; });
+
+    // What the list is about to show, so a group's clear-down verifies exactly the rows on screen
+    // (including in a collapsed group, whose rows are not in the DOM until it is expanded).
+    page._shown = displayItems;
 
     var streamable = page.querySelector('#cgStreamable').checked;
     var empty;
@@ -2464,6 +2668,20 @@ function todoAmazonUrl(entry) {
     return 'https://www.amazon.com/s?k=' + encodeURIComponent(todoSearchTerm(entry));
 }
 
+// Check every todo entry against the library in one pass, tick the ones you now hold, and re-render
+// the popup from what comes back. Both the "Verify all" button and the export run this, so a list you
+// are about to read (on screen or in a file) has just been reconciled with the library.
+function verifyAllTodo(modal) {
+    return ApiClient.ajax({ type: 'POST', url: ApiClient.getUrl('MindTheGaps/Todo/VerifyAll'), dataType: 'json' })
+        .then(function (res) {
+            if (res && res.Items) {
+                modal._data = { Items: res.Items, SearchUrlTemplate: (modal._data || {}).SearchUrlTemplate };
+                renderTodo(modal);
+            }
+            return res;
+        });
+}
+
 // POST helper for the single-id Todo endpoints (Remove / SetDone / Verify), all query-string args.
 function todoPost(path, args) {
     return ApiClient.ajax({ type: 'POST', url: ApiClient.getUrl('MindTheGaps/' + path, args), dataType: 'json' });
@@ -2762,8 +2980,29 @@ document.querySelector('#MindTheGapsPage').addEventListener('pageshow', function
     document.getElementById('cgTodoModal').addEventListener('click', function (e) {
         if (e.target === this) { closeTodo(); }
     });
+    document.getElementById('cgTodoVerifyAll').addEventListener('click', function () {
+        var modal = document.getElementById('cgTodoModal');
+        Dashboard.showLoadingMsg();
+        verifyAllTodo(modal).then(function (res) {
+            Dashboard.hideLoadingMsg();
+            Dashboard.alert('Checked ' + ((res && res.Checked) || 0) + ' entry(s); you have ' + ((res && res.Owned) || 0) + ' of them.');
+        }).catch(function () {
+            Dashboard.hideLoadingMsg();
+            Dashboard.alert('Could not check your library. Check the server logs.');
+        });
+    });
+    // Verify before writing the file, so the exported checklist's ticks are true as of the download
+    // rather than as of whenever each entry was last checked by hand.
     document.getElementById('cgTodoExport').addEventListener('click', function () {
-        downloadText('mind-the-gaps-todo.md', buildTodoMarkdown(document.getElementById('cgTodoModal')));
+        var modal = document.getElementById('cgTodoModal');
+        Dashboard.showLoadingMsg();
+        verifyAllTodo(modal).catch(function () {
+            // A failed check must not cost you the export; fall back to writing what is on screen.
+            Dashboard.alert('Could not check your library first, so the export reflects the list as it stands.');
+        }).then(function () {
+            Dashboard.hideLoadingMsg();
+            downloadText('mind-the-gaps-todo.md', buildTodoMarkdown(modal));
+        });
     });
     document.getElementById('cgTodoBody').addEventListener('change', function (e) {
         var box = e.target.closest ? e.target.closest('.cgTodoDoneBox') : null;
@@ -2957,22 +3196,77 @@ document.querySelector('#MindTheGapsPage').addEventListener('pageshow', function
             .then(function () { fetchResolved().then(function () { applyAndRender(page); }); })
             .catch(function () { Dashboard.alert('Could not restore the creator. Check the server logs.'); });
     });
+    // Export verifies what it is about to write first, so the file is a list of things you actually
+    // still need rather than a snapshot of whatever the last scan believed. That drops the rows you now
+    // hold from the report as well, which is the same clear-down the refresh controls run, so it says
+    // what it cleared rather than doing it silently.
     page.querySelector('#cgExport').addEventListener('click', function () {
         if (!page._report) { return; }
-        // Name the file by the active domain and the domain-aware pattern label (the same words
-        // shown on screen), each lowercased with all whitespace turned to hyphens, so it reads
-        // consistently and each domain's export of a pattern keeps its own filename.
-        var typeSel = page.querySelector('#cgTypeFilter');
-        var domainValue = (typeSel && typeSel.value) || '';
-        var label = page._pattern ? patternLabel(page._pattern, domainValue) : 'report';
-        var parts = [domainValue, label].filter(Boolean).map(slugify).join('-');
-        downloadText('mind-the-gaps-' + parts + '.md', buildMarkdown(page));
+        var write = function () {
+            // Name the file by the active domain and the domain-aware pattern label (the same words
+            // shown on screen), each lowercased with all whitespace turned to hyphens, so it reads
+            // consistently and each domain's export of a pattern keeps its own filename.
+            var typeSel = page.querySelector('#cgTypeFilter');
+            var domainValue = (typeSel && typeSel.value) || '';
+            var label = page._pattern ? patternLabel(page._pattern, domainValue) : 'report';
+            var parts = [domainValue, label].filter(Boolean).map(slugify).join('-');
+            downloadText('mind-the-gaps-' + parts + '.md', buildMarkdown(page));
+        };
+
+        // Verify exactly what is about to be written, not just the letter on screen.
+        var toWrite = exportItems(page);
+        if (!toWrite.length) { write(); return; }
+
+        Dashboard.showLoadingMsg();
+        verifyGaps(page, toWrite.map(function (it) { return it.Id; })).then(function (res) {
+            Dashboard.hideLoadingMsg();
+            var cleared = (res && res.Removed) || 0;
+            if (cleared) {
+                applyAndRender(page);
+                Dashboard.alert('Cleared ' + cleared + ' item(s) you already have; the export leaves them out.');
+            }
+
+            // Write after the re-render, so the file matches what the screen now shows.
+            write();
+        }).catch(function () {
+            // A failed check must not cost you the export; fall back to writing what is on screen.
+            Dashboard.hideLoadingMsg();
+            Dashboard.alert('Could not check your library first, so the export reflects the list as it stands.');
+            write();
+        });
     });
     page.querySelector('#cgExploreBtn').addEventListener('click', function () {
         openExplore(page);
     });
     page.querySelector('#cgTodoBtn').addEventListener('click', function () {
         openTodo();
+    });
+    // The rollup line sits outside the list, so its clear-down control needs its own delegation. It
+    // scopes to one media domain, which on a tab with no kind headings (Creator works, Discover, or a
+    // Set completion whose domain has a single kind) is the only level between a group and the tab.
+    page.querySelector('#cgRollup').addEventListener('click', function (e) {
+        var rEl = e.target.closest ? e.target.closest('.cgClear') : null;
+        if (!rEl) { return; }
+        var rKey = rEl.getAttribute('data-key') || '';
+        var rRows = rowsInScope(page, 'domain', rKey);
+        if (!rRows.length) { return; }
+        if (!window.confirm('Check all ' + rRows.length + ' item(s) under ' + rKey + ' against your library and clear the ones you have?')) { return; }
+        rEl.classList.add('cgBusy');
+        clearDownScope(page, rRows, ' under ' + rKey)
+            .catch(function () { Dashboard.alert('Could not check your library. Check the server logs.'); })
+            .then(function () { rEl.classList.remove('cgBusy'); });
+    });
+    // The whole filtered tab at once, the widest scope of the same routine. The count is confirmed
+    // first because it is not undoable in place (a cleared row comes back on the next scan only if it
+    // is genuinely still missing).
+    page.querySelector('#cgVerifyShown').addEventListener('click', function () {
+        var shown = page._shown || [];
+        if (!shown.length) { Dashboard.alert('Nothing shown to check.'); return; }
+        if (!window.confirm('Check all ' + shown.length + ' shown item(s) against your library and clear the ones you have?')) { return; }
+        Dashboard.showLoadingMsg();
+        clearDownScope(page, shown, '')
+            .catch(function () { Dashboard.alert('Could not check your library. Check the server logs.'); })
+            .then(function () { Dashboard.hideLoadingMsg(); });
     });
     page.querySelector('#cgJump').addEventListener('click', function (e) {
         var a = e.target.closest ? e.target.closest('.cgJumpL') : null;
@@ -3123,24 +3417,24 @@ document.querySelector('#MindTheGapsPage').addEventListener('pageshow', function
             return;
         }
 
-        // Re-check one series now (the refresh icon on a series or season header): the server
-        // swaps just this series' gaps, so a metadata fix can be verified without a full rescan.
-        // Invalidate the cached slice for the current tab, then re-fetch and re-render.
-        var rkBtn = e.target.closest('.cgRecheck');
-        if (rkBtn) {
-            var rkSeries = rkBtn.getAttribute('data-series');
-            if (!rkSeries) { return; }
-            rkBtn.classList.add('cgBusy');
-            ApiClient.ajax({ type: 'POST', url: ApiClient.getUrl('MindTheGaps/RecheckSeries', { seriesId: rkSeries }), dataType: 'json' })
-                .then(function () {
-                    if (page._slices) { page._slices[page._pattern] = null; }
-                    return ensureSlice(page, page._pattern);
-                })
-                .then(function () { applyAndRender(page); })
-                .catch(function () {
-                    rkBtn.classList.remove('cgBusy');
-                    Dashboard.alert('Could not re-check the series. Check the server logs.');
-                });
+        // The one clear-down control, wherever it was clicked. The scope decides which of the rows on
+        // screen it covers; the behaviour past that is identical at every level.
+        var clearEl = e.target.closest('.cgClear');
+        if (clearEl) {
+            var scope = clearEl.getAttribute('data-scope') || '';
+            var key = clearEl.getAttribute('data-key') || '';
+            var picked = rowsInScope(page, scope, key);
+            if (!picked.length) { return; }
+            // Only the wide scopes confirm first: a row or a season is small enough to just do.
+            if ((scope === 'domain' || scope === 'kind')
+                && !window.confirm('Check all ' + picked.length + ' item(s) here against your library and clear the ones you have?')) {
+                return;
+            }
+
+            clearEl.classList.add('cgBusy');
+            clearDownScope(page, picked, scopeLabel(scope, key, picked))
+                .catch(function () { Dashboard.alert('Could not check your library. Check the server logs.'); })
+                .then(function () { clearEl.classList.remove('cgBusy'); });
             return;
         }
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ flowchart TD
   item, the matching rules, the plugin verdict, the owned candidates, and an analysis prompt) to hand to any
   AI, and an identification audit runs the same check across the domain and pattern you are viewing and
   downloads as Markdown.
+- **Clear down what you have filled**: one refresh control on every row and every heading (a domain, a set
+  kind, a group, a season) plus a **Clear what I have** button for the whole visible list. It checks your
+  library right now and drops the rows you already hold: local, instant, no provider contacted, every domain
+  and kind. A title you have acquired leaves every tab it was on at once, so one film clears out of its
+  collection, the studio set that wanted it, its director's filmography, and any list that suggested it. Anything still missing then prompts to re-check the sources it belongs to against their
+  providers, which also picks up what has been added since the last scan.
 - **Batch and whole-set dismissals**: resolve or mark "not interested" every episode under a series or
   season at once, or dismiss a whole creator or recommendation source so it stops being scanned.
 - **Dismiss a gap**: mark it **resolved** (not really missing, for example two listed episodes that are a

--- a/docs/adr/0013-recheck-one-series.md
+++ b/docs/adr/0013-recheck-one-series.md
@@ -29,3 +29,9 @@ served from the read-through cache.
 - It runs in the request rather than the background (unlike a full scan or an explore), which is fine for
   one series but would not be for the whole library; a wholly cold cross-check cache makes the first
   re-check of a show a few live calls, then cached.
+
+Superseded in part by [ADR-0016](0016-verify-first-clear-down.md), which generalized this to any owning item.
+`CheckSeriesAsync` and the per-series behaviour are unchanged, but the entry points folded together: the
+`RecheckSeries` endpoint and `GapStore.ReplaceSeriesGaps` are now the general `RecheckSources` and
+`ReplaceSourceGaps`, which dispatch on what the owning item is, and the refresh icon this ADR put on a series
+header is now the one clear-down control the whole report uses.

--- a/docs/adr/0016-verify-first-clear-down.md
+++ b/docs/adr/0016-verify-first-clear-down.md
@@ -1,0 +1,98 @@
+# 16. Clear down a filled gap anywhere: verify first, re-check on request
+
+Status: Accepted.
+
+## Context
+
+[ADR-0013](0013-recheck-one-series.md) gave a series a refresh icon that re-runs its sources in place, so a
+metadata fix could be verified without a full rescan. Nothing equivalent existed for the rest of the report:
+having actually acquired a movie from a collection, an album from a discography, or a book from a
+bibliography, the only way to get the row off the list was a full scan (and for the rotating patterns, a scan
+that happened to revisit that seed).
+
+Two different operations were being asked for under one name. "I filled this gap, clear it" only needs to
+know what the library holds now. "Has this set changed?" needs the provider asked again. They cost very
+different amounts: the first is a local, indexed query, the second is a live API call plus, for the sources
+that diff against the whole library, an ownership index.
+
+## Decision
+
+Split them, and lead with the cheap one.
+
+`LibraryVerifier` answers "does the library hold this one gap now?" with a focused `HasAnyProviderId` query
+per gap, rather than the library-wide read `GapEngine.BuildOwnershipIndex` does. It mirrors the scan's
+ownership rules, including the album artist-and-title name fallback, and deliberately no wider: clearing a
+row the next scan would only re-report is worse than leaving it listed. It is kind-agnostic, so it works for
+every domain, pattern, and target kind with no per-source code. `POST Verify` takes gap ids and rehydrates
+each server-side.
+
+Confirming one title owned then clears every gap about that title, not only the row that was clicked. A
+missing film is normally several gaps with several ids: a hole in its collection, in a studio set, in its
+director's filmography, in a curated list, and a recommendation. `GapTargetKey` gives a gap the identity of
+its subject rather than of itself, keyed the way `OwnershipIndex` keys the library (any shared provider id
+under the same kind, plus the album name key), and `GapStore.RemoveGaps` drops everything matching.
+
+`ISetContentSource` is the per-owning-item seam, the set-shaped sibling of `ISeriesContentSource`: a
+`Claims(owner)` predicate, a `CheckOneAsync(owner, ...)` step, and the `GapIdPrefix` its gaps carry.
+`CollectionGapSource`, `MusicArtistGapSourceBase` (both music providers), and `BooksBibliographyGapSource`
+implement it, in each case by exposing the per-entity step their scan loop already had.
+`GapEngine.RecheckManyAsync` dispatches per owner on what it is (set claimants, else a series through the
+series-content sources) and `GapStore.ReplaceSourceGaps` swaps out exactly those sources' gaps for that
+owner. ADR-0013's `RecheckSeries` endpoint and `ReplaceSeriesGaps` are folded into these rather than left
+beside them: two endpoints differing only by the owner's kind was an accident of the order they were written,
+and gave no answer for a music artist.
+
+The dashboard exposes one control for both, the refresh icon, at every level of the tree and on every row:
+the domain rollup, a set-kind heading, a group header, a season header, and a row. A labelled "Clear what I
+have" button in the toolbar is the same routine over the whole filtered tab, spelled as a button because the
+toolbar has no row to hang an icon on. All of them run one routine at a different width, so there is one
+behaviour to learn and nothing to choose between; a level is a `data-scope`, not a code path. ADR-0013's
+per-series refresh icon is that same control now, not a second one beside it.
+
+The multi-owner half is a batch: `GapEngine.RecheckManyAsync` builds the ownership index once rather than per
+item, runs behind `RecheckRunner` (the background-runner shape the scan and the explore use), and swaps each
+item into the report as it finishes. Every re-check goes through it, a single group being a batch of one, so
+the API is one pair, `RecheckSources` and `RecheckStatus`, rather than a single-item endpoint and a batch
+one. It re-checks only the sources that still had gaps after the verify, and it dispatches on what the owning
+item is, so a series routes to the series-content sources and the Shows tab works the same as the Movies one.
+
+## Consequences
+
+- Filling a gap can be cleared from anywhere in the report, in any domain, with no provider call and no
+  rescan. The expensive half is never spent on the common case.
+- Acquiring one title clears it from every tab it appeared on at once, including tabs the client has not
+  loaded, which is why the sweep is server-side: the client cannot prune what it has not fetched. The verify
+  response therefore reports a removal count higher than the number of rows in scope, and the dashboard says
+  how many went elsewhere rather than letting the totals move unexplained.
+- The scopes are one behaviour at six widths, so there is nothing new to learn moving up the tree, and the
+  batch stage never runs without a count in the prompt first.
+- The clear-down is offered in places its second stage cannot serve (a studio, a curated list, a film
+  filmography), where it degrades to the verify half. That is deliberate: a control that appears and
+  disappears by source would be harder to learn than one that is always there and sometimes offers less.
+- A batch re-check writes per item, so cancelling it (or a shutdown) leaves a partially refreshed report
+  rather than an all-or-nothing one. That is the right trade for a report that is already a running estimate,
+  but it does mean two sets under one heading can carry different freshness.
+- A source that cannot answer returns null rather than an empty list, and only a source that answered has
+  its gaps replaced. Without that distinction a transient provider outage reads as "this collection is
+  complete" and deletes its real gaps, which a re-check has no way to restore. Cancellation propagates for
+  the same reason: an interrupted owner must not be committed as a successful empty re-check.
+- Gap identity is transitive across provider ids. One title's rows do not all carry the same ids (the
+  availability pass resolves an IMDb id onto some and not others), so a TMDB-only row and an IMDb-only row
+  are the same film linked only through a row carrying both. `GapTargetKey` grows its key set through what
+  it matches until nothing new appears, so clearing any one representation clears them all rather than only
+  those the clicked row happened to overlap.
+- Verify clears filled gaps but never discovers new ones, which is why the re-check prompt exists where a
+  source supports it. The filmography and recommendation sources were left without the seam: they scan a
+  slice of their seeds per run and accumulate across scans (ADR-0012), so a per-creator re-check would cut
+  across that model, and their value is discovery rather than completing a set you can point at. Those groups
+  get the verify half only. Nothing structural stops the seam being added later.
+- The verify name fallback is an exact-title query plus a normalized compare, slightly narrower than the
+  index's fully normalized key. Like `OwnershipIndex.OwnsByName`, it can only fail toward leaving a gap
+  listed. It stays album-only because that is all `BuildOwnershipIndex` name-keys.
+- Both are partial updates: neither bumps the report's scan time or version, so neither clears the
+  post-upgrade rescan nudge. An owning item nothing claims is skipped before the batch starts rather than
+  re-checked to an empty result, so a mis-aimed call cannot silently wipe that item's gaps; the client also
+  only offers the prompt for owners it knows can be re-run.
+- The dashboard prunes cleared ids from every cached tab, then re-reads the summary. It cannot count what it
+  never loaded, and the sweep's whole point is clearing rows on tabs the browser has not opened, so the
+  counts have to come from the server rather than from local arithmetic.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,3 +20,4 @@ context, the decision, and what it costs, so the reasoning survives the code.
 | [0013](0013-recheck-one-series.md) | Re-check one series in place, without a full rescan |
 | [0014](0014-tmdb-episode-source-and-provider-priority.md) | A TheMovieDb episode source, and honor the library's provider priority |
 | [0015](0015-merge-episodes-per-season-library-driven.md) | Merge every provider's episodes per season; the library drives which run |
+| [0016](0016-verify-first-clear-down.md) | Clear down a filled gap anywhere: verify first, re-check on request |

--- a/docs/report-guide.md
+++ b/docs/report-guide.md
@@ -110,11 +110,13 @@ The toolbar applies to the current tab. Filters combine (a row must pass all of 
 | **Hide items with no sources** | Hide gaps with no "where to watch" match for your provider filter. Needs availability data first (see below). |
 | **Look up where to watch** | Kicks off the background availability pass: fetches streaming providers for the gaps that do not have them yet, in batches, filling in as it goes. Grouped by watch target, so every episode of a series shares one lookup. The button shows how many titles still need a lookup ("Look up where to watch (N)"), reports live progress while running ("Looking up... 45/320"), and reads "Where to watch: all checked" (disabled) once the backlog is cleared. Requires **Availability** enabled in settings. |
 | **Provider filter** | When availability data is present, filter to specific streaming providers. |
-| **Export Markdown** | Download the current tab, as filtered, as a Markdown file with links. |
+| **Export Markdown** | Check the rows it is about to write against your library, drop the ones you now hold, then download the current tab as filtered as a Markdown file with links. Exporting therefore clears what you already have, and says how many; the file is a list of what you still need rather than a snapshot of what the last scan believed. If the check fails, it exports the list as it stands and tells you so. |
 | **Search** | Free-text filter on the title. |
 | **Saved views** | Save the current set of filters under a name and re-apply later; **Save current** / **Delete**. Views are stored per browser. |
 | **Copy link** | Copy a URL that re-opens this exact view (active tab plus every filter) when pasted into another browser or shared. Opening such a link applies the view once, then drops the marker from the address bar so a later reload uses your own saved filters. Unlike a saved view, the link is not tied to one browser. |
+| **My TODO list** | Open your personal pick-list of gaps to go find, built with the per-row **TODO** button or the multi-select bar. It survives rescans, groups by domain, and each entry has a done tick, links, a **Verify** that checks your library for that one title, and **Delete**. **Verify all** checks every entry at once and ticks what you now hold (and un-ticks anything that has left the library). **Export Markdown** runs that same check first, then downloads the list as a checklist, so the ticks in the file are true as of the download. |
 | **Explore a source** | Open a modal that pulls the unowned titles from one source right now and merges them into the report, without a full rescan and without changing your saved settings. See [Explore a source on demand](#explore-a-source-on-demand). |
+| **Clear what I have** | The widest scope of the clear-down described under [Per-row actions](#per-row-actions): checks every row currently shown against your library, drops the ones you now hold, then offers a provider re-check for what is left. Confirms the count first. |
 
 ![Where to watch](screenshots/report-streaming-providers.png)
 
@@ -151,9 +153,36 @@ Each gap row carries links and actions. Which appear depends on the gap's kind a
 - **Batch dismiss a series or season**: on the **Shows** Set completion tree, each series and season group
   header carries **Resolve all** / **Not interested in all**, which dismiss every listed episode under that
   group in one step (after a confirm). They act on the episodes currently shown, so any filter applies.
-- **Re-check a series or season**: the same headers carry a **refresh** icon that re-checks just that one
-  series on the spot (the library reader plus the enabled TVmaze/TheTVDB cross-checks), replacing its gaps
-  in place, so you can confirm a metadata fix without a full rescan.
+- **Clear down (the refresh icon)**: one control, on every level and every row, doing the same thing at
+  different widths. It first checks everything in scope against your library and drops what you now hold,
+  which is local, instant, and contacts no provider. Confirming a title clears it from **every** tab it
+  appeared on, not just the one you are looking at: acquiring Mad Max 2 drops it from the Mad Max collection,
+  from the studio set that wanted it, from its director's filmography, and from any recommendation or list
+  that suggested it, in one go. If anything is still missing and its source can be
+  re-run for one item, it then offers to ask the providers again, which also picks up whatever has been
+  added since the last scan. That second step is always a prompt, so the everyday case (I filled these,
+  clear them) stays one click and never spends a provider call.
+
+  The scopes, widest first:
+
+  | Where | Covers |
+  |---|---|
+  | The rollup line ("Shows: 679 gaps across 17 sets") | every row shown for that domain |
+  | A Set completion kind heading (Collections and franchises, Studios, Keywords, Discography, Record labels) | every row under that kind |
+  | Any group header (a collection, studio, keyword, series, artist, author, creator, curated list, recommendation seed) | every row listed under it |
+  | A season header | that season's episodes |
+  | Any row | that one title |
+  | **Clear what I have** in the toolbar | the whole filtered tab |
+
+  Kind headings only render when a domain's Set completion holds more than one kind, so **Shows** has none;
+  its rollup line is the level above the series groups. **Creator works** and **Discover** group straight by
+  source and have no kind level at all, so the same applies there.
+
+  The re-check half is offered only for sources the server can re-run per item: a movie collection, a music
+  artist, a book author, and a series. A studio, keyword, Discogs label, or curated list is keyed to a
+  synthetic id rather than a library item, and a film filmography or recommendation seed would need a
+  library-wide ownership pass, so those get the library check alone. A re-check covering more than one
+  source runs in the background with progress and saves each one as it finishes.
 
 Resolving a gap can carry an optional note (for example why it is not really missing):
 


### PR DESCRIPTION
One refresh control on every row and every heading (domain, set kind, group, season), plus a "Clear what I have" button for the whole filtered tab. It checks the library and drops what you now hold, then offers a provider re-check for whatever is still missing.

LibraryVerifier answers "is this one gap filled?" with a focused HasAnyProviderId query instead of the library-wide read a scan does, mirroring the scan's ownership rules and no wider. Confirming a title clears every gap about it, not just the row clicked: a film is a hole in its collection, a studio set, a filmography, a list, and a recommendation, each with its own id, so GapTargetKey matches by subject and the sweep runs server-side where tabs the client never loaded can be reached.

ISetContentSource is the per-owning-item re-check seam, the set-shaped sibling of ISeriesContentSource: Claims, CheckOneAsync, GapIdPrefix. CollectionGapSource, MusicArtistGapSourceBase, and BooksBibliographyGapSource implement it by exposing the per-entity step their scan loop already had. RecheckManyAsync dispatches per owner (set claimants, else a series), builds the ownership index once per batch, and runs behind RecheckRunner so a heading covering hundreds of sets cannot time out a request; each owner is saved as it finishes.

The TODO list checks the same way: TodoController drops its own ids-only ownership test for LibraryVerifier, so a Discogs-sourced album can no longer read as owned on the report and missing on the TODO list. Todo/VerifyAll checks the whole list at once and stamps done both ways, so an entry whose file has left the library becomes outstanding again.

Both Markdown exports verify before writing. The report's export clears what you already have and says so; the TODO export reconciles its ticks first. A failed check never costs the export, which falls back to writing the list as it stands.

The re-check API is one pair, RecheckSources and RecheckStatus. RecheckSeries and ReplaceSeriesGaps fold into them.

See ADR-0016.
